### PR TITLE
Add production deployment to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,28 +9,43 @@ env:
     - PYTHONPATH=$PYTHONPATH:$(pwd)/cidc-api
     - CLOUDSDK_CORE_DISABLE_PROMPTS=1
     - GOOGLE_APPLICATION_CREDENTIALS=$HOME/credentials.json
-    - GCLOUD_PROJECT_ID=cidc-dfci-staging
+    - GCLOUD_PROJECT_ID_STAGING=cidc-dfci-staging
+    - GCLOUD_PROJECT_ID_PROD=cidc-dfci
 before_install:
   # Install and configure the gcloud SDK. Values for these environment 
   # variables must be set in the Travis CI console for this to work:
-  #   GCLOUD_SERVICE_ACCOUNT_JSON : Travis CI service account credentials
-  #   [TODO: any others?]
+  #   GCLOUD_SERVICE_ACCOUNT_JSON_STAGING
+  #     -> base64-encoded service account JSON credentials for the staging project
+  #   GCLOUD_SERVICE_ACCOUNT_JSON_PROD 
+  #     -> base64-encoded service account JSON credentials for the production project
   - if [ ! -d ${HOME}/google-cloud-sdk/bin ]; then
       rm -rf $HOME/google-cloud-sdk;
       curl https://sdk.cloud.google.com | bash > /dev/null;
     fi
   - source $HOME/google-cloud-sdk/path.bash.inc
-  - gcloud config set project $GCLOUD_PROJECT_ID
-  - echo "${GCLOUD_SERVICE_ACCOUNT_JSON}" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
+  - if [ "$TRAVIS_BRANCH" = production ]; then
+      gcloud config set project $GCLOUD_PROJECT_ID_PROD
+      export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_PROD"
+    else
+      gcloud config set project $GCLOUD_PROJECT_ID_STAGING
+      export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING"
+    fi
+  - echo "$GCLOUD_SERVICE_ACCOUNT_JSON" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
   - gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
 install:
   - pip install -r requirements.txt -r requirements.dev.txt
 script:
   - PYTHONPATH=$PYTHONPATH:$HOME/cidc-api pytest
   - black --check cidc-api --target-version=py36
+
 deploy:
-  provider: gae
-  keyfile: $GOOGLE_APPLICATION_CREDENTIALS
-  project: $GCLOUD_PROJECT_ID
-  config: app.staging.yaml
-  branch: master
+  - provider: gae
+    keyfile: $GOOGLE_APPLICATION_CREDENTIALS
+    project: $GCLOUD_PROJECT_ID
+    config: app.staging.yaml
+    branch: master
+  - provider: gae
+    keyfile: $GOOGLE_APPLICATION_CREDENTIALS
+    project: $GCLOUD_PROJECT_ID
+    config: app.prod.yaml
+    branch: production

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ before_install:
     fi
   - source $HOME/google-cloud-sdk/path.bash.inc
   - if [ "$TRAVIS_BRANCH" = production ]; then
-      gcloud config set project $GCLOUD_PROJECT_ID_PROD
-      export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_PROD"
+      gcloud config set project $GCLOUD_PROJECT_ID_PROD;
+      export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_PROD";
     else
-      gcloud config set project $GCLOUD_PROJECT_ID_STAGING
-      export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING"
+      gcloud config set project $GCLOUD_PROJECT_ID_STAGING;
+      export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING";
     fi
   - echo "$GCLOUD_SERVICE_ACCOUNT_JSON" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
   - gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
@@ -41,11 +41,13 @@ script:
 deploy:
   - provider: gae
     keyfile: $GOOGLE_APPLICATION_CREDENTIALS
-    project: $GCLOUD_PROJECT_ID
+    project: $GCLOUD_PROJECT_ID_STAGING
     config: app.staging.yaml
-    branch: master
+    on:
+      branch: master
   - provider: gae
     keyfile: $GOOGLE_APPLICATION_CREDENTIALS
-    project: $GCLOUD_PROJECT_ID
+    project: $GCLOUD_PROJECT_ID_PROD
     config: app.prod.yaml
-    branch: production
+    on:
+      branch: production

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The next generation of the CIDC API, reworked to use Google Cloud-managed servic
 - [Testing](#Testing)
 - [Code Formatting](#Code-Formatting)
 - [Deployment](#Deployment)
+  - [CI/CD](#CICD)
+  - [Deploying by hand](#Deploying-by-hand)
 
 
 ## Install Python dependencies
@@ -87,9 +89,22 @@ This project uses [`black`](https://black.readthedocs.io/en/stable/) for code st
 We recommend setting up autoformatting-on-save in your IDE of choice so that you don't have to worry about running `black` on your code.
 
 ## Deployment
-Deploy the application to Google App Engine by running the following:
+
+### CI/CD
+
+This project uses [Travis CI](https://travis-ci.org/) for continuous integration and deployment. To deploy an update to this application, follow these steps:
+1. Create a new branch locally, commit updates to it, then push that branch to this repository.
+2. Make a pull request from your branch into `master`. This will trigger Travis to run various tests and report back success or failure. You can't merge your PR until it passes the Travis build, so if the build fails, you'll probably need to fix your code.
+3. Once the Travis build passes (and pending approval from collaborators reviewing the PR), merge your changes into `master`. This will trigger Travis to re-run tests on the code then deploy changes to the staging API.
+4. Try out your deployed changes on the staging API once the Travis build completes.
+5. If you're satisfied that staging should be deployed into production, make a PR from `master` into `production`. 
+6. Once the PR build passes, merge `master` into `production`. This will trigger Travis to deploy the changes on staging to the production API.
+
+For more information or to update the Travis pipeline, check out the configuration in `.travis.yml`.
+
+### Deploying by hand
+Should you ever need to deploy the application to Google App Engine by hand, you can do so by running the following:
 ```bash
 gcloud app deploy <app.staging.yaml or app.prod.yaml> --project <gcloud project id>
 ```
-
-Going forward, deployment will happen as part the Travis CI pipeline, and we shouldn't need to deploy by hand.
+That being said, avoid doing this! Deploying this way circumvents the safety checks built into the CI/CD pipeline and can lead to inconsistencies between the code running on GAE and the code present in this repository. Luckily, though, GAE's built-in versioning system makes it hard to do anything catastrophic :-)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # CIDC API <!-- omit in TOC -->
 
+| Environment | Branch                                                                   | Status                                                                                                                                |
+| ----------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| production  | [production](https://github.com/CIMAC-CIDC/cidc-api-gae/tree/production) | [![Build Status](https://travis-ci.org/CIMAC-CIDC/cidc-api-gae.svg?branch=production)](https://travis-ci.org/CIMAC-CIDC/cidc-api-gae) |
+| staging     | [master](https://github.com/CIMAC-CIDC/cidc-api-gae)                     | [![Build Status](https://travis-ci.org/CIMAC-CIDC/cidc-api-gae.svg?branch=master)](https://travis-ci.org/CIMAC-CIDC/cidc-api-gae)     |
+
+
 The next generation of the CIDC API, reworked to use Google Cloud-managed services. This API is built with the Eve REST API framework backed by Google Cloud SQL, running on Google App Engine.
 
 # Development <!-- omit in TOC -->

--- a/app.prod.yaml
+++ b/app.prod.yaml
@@ -1,0 +1,13 @@
+runtime: python37
+env: standard
+entrypoint: gunicorn -b :$PORT --chdir cidc-api app:app
+
+env_variables:
+  ENV: 'prod'
+  SECRETS_BUCKET_NAME: 'cidc-secrets-prod'
+  AUTH0_DOMAIN: 'cidc.auth0.com'
+  AUTH0_AUDIENCE: 'prod-api'
+  AUTH0_CLIENT_ID: 'hh09Teq5oiwduZTVjUJKrJvh21qxN4Dn'
+  CLOUD_SQL_INSTANCE_NAME: 'cidc-dfci:us-central1:cidc-postgres'
+  CLOUD_SQL_DB_USER: 'postgres'
+  CLOUD_SQL_DB_NAME: 'cidc'

--- a/cidc-api/settings.py
+++ b/cidc-api/settings.py
@@ -44,16 +44,12 @@ if not POSTGRES_URI:
         config["query"] = {
             "host": "/cloudsql/%s" % environ.get("CLOUD_SQL_INSTANCE_NAME")
         }
-    elif environ.get("CLOUD_SQL_DB_HOST"):
+    else:
         # If CLOUD_SQL_DB_HOST is defined, we're connecting via
         # the database's public IP address. Google secures this
         # IP address for us, but it's still a good idea to keep
         # it a secret.
         config["host"] = secrets.get("CLOUD_SQL_DB_HOST")
-    else:
-        raise EnvironmentError(
-            "POSTGRES_URI, CLOUD_SQL_INSTANCE_NAME, or CLOUD_SQL_DB_IP must be defined to connect to the database"
-        )
 
     POSTGRES_URI = str(URL(**config))
 


### PR DESCRIPTION
Now, when changes are pushed to this branch, those changes are deployed to the production API instance.

This is the *only* time that the `production` branch will be merged into `master`. Going forward, the `production` branch should only be updated via PRs made from `master` into `production`.