### PR TITLE
Signed URL endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -19,3 +19,4 @@ POSTGRES_URI='postgresql://cidcdev:1234@localhost:5432/cidc'
 # CLOUD_SQL_DB_NAME='cidc'
 
 SECRETS_BUCKET_NAME='cidc-secrets-staging'
+GOOGLE_UPLOAD_BUCKET='cidc-uploads-staging'

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,3 +1,5 @@
+tests
+
 .git
 
 # IDE configuration files

--- a/app.prod.yaml
+++ b/app.prod.yaml
@@ -11,3 +11,4 @@ env_variables:
   CLOUD_SQL_INSTANCE_NAME: 'cidc-dfci:us-central1:cidc-postgres'
   CLOUD_SQL_DB_USER: 'postgres'
   CLOUD_SQL_DB_NAME: 'cidc'
+  GOOGLE_UPLOAD_BUCKET: 'cidc-uploads-prod'

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -11,3 +11,4 @@ env_variables:
   CLOUD_SQL_INSTANCE_NAME: 'cidc-dfci-staging:us-central1:cidc-postgres'
   CLOUD_SQL_DB_USER: 'postgres'
   CLOUD_SQL_DB_NAME: 'cidc'
+  GOOGLE_UPLOAD_BUCKET: 'cidc-uploads-staging'

--- a/cidc-api/services/ingestion.py
+++ b/cidc-api/services/ingestion.py
@@ -2,13 +2,17 @@
 Endpoints for validating and ingesting metadata and data.
 """
 import json
+import datetime
 from typing import BinaryIO, Tuple
 
 from werkzeug.exceptions import BadRequest, InternalServerError, NotImplemented
 
+from google.cloud import storage
 from eve.auth import requires_auth
 from flask import Blueprint, request, jsonify
 from cidc_schemas import constants, validate_xlsx
+
+from settings import GOOGLE_UPLOAD_BUCKET
 
 ingestion_api = Blueprint("ingestion", __name__, url_prefix="/ingestion")
 
@@ -82,4 +86,71 @@ def validate():
 @ingestion_api.route("/upload", methods=["POST"])
 @requires_auth("ingestion.upload")
 def upload():
+    """Ingest the metadata associated with a completed upload."""
     raise NotImplemented()
+
+
+@ingestion_api.route("/signed-upload-urls", methods=["POST"])
+@requires_auth("ingestion.signed-upload-urls")
+def signed_upload_urls():
+    """
+    Given a request whose body contains a directory name and a list of object names,
+    return a JSON object mapping object names to signed GCS upload URLs for those objects.
+
+    Note: a signed URL gives time-restricted, method-restricted access to one of our GCS
+    storage buckets
+
+    TODO: In the long run, this endpoint *needs* user-level rate-limiting or similar. If we don't keep 
+    track of how recently we've issued signed URLs to a certain user, then that user can
+    keep acquiring signed URLs over and over, effectively circumventing the time-restrictions
+    built into these URLs. For now, though, since only people on the development team are
+    registered in the app, we don't need to worry about this.
+
+    Sample request body:
+    {
+        "directory_name": "my-assay-run-id",
+        "object_names": ["my-fastq-1.fastq.gz", "my-fastq-2.fastq.gz"]
+    }
+
+    Sample response body:
+    {
+        "my-fastq-1.fastq.gz": [a signed URL with PUT permissions],
+        "my-fastq-2.fastq.gz": [a signed URL with PUT permissions]
+    }
+    """
+    # Validate the request body
+    if not request.json:
+        raise BadRequest("expected JSON request body.")
+    if not "directory_name" in request.json and "object_names" in request.json:
+        raise BadRequest(
+            "expected keys 'directory_name' and 'object_names' in request body."
+        )
+
+    directory_name = request.json["directory_name"]
+    object_urls = {}
+    # Build up the mapping of object names to buckets
+    for object_name in request.json["object_names"]:
+        # Prepend objects with the given directory name
+        full_object_name = f"{directory_name}/{object_name}"
+        object_url = get_signed_url(full_object_name)
+        object_urls[object_name] = object_url
+
+    return jsonify(object_urls)
+
+
+def get_signed_url(object_name: str, method: str = "PUT", expiry_mins: int = 5) -> str:
+    """
+    Generate a signed URL for `object_name` to give a client temporary access.
+
+    See: https://cloud.google.com/storage/docs/access-control/signing-urls-with-helpers
+    """
+    storage_client = storage.Client()
+    bucket = storage_client.get_bucket(GOOGLE_UPLOAD_BUCKET)
+    blob = bucket.blob(object_name)
+
+    # Generate the signed URL, allowing a client to use `method` for `expiry_mins` minutes
+    expiration = datetime.timedelta(minutes=expiry_mins)
+    url = blob.generate_signed_url(version="v4", expiration=expiration, method=method)
+
+    return url
+

--- a/cidc-api/services/ingestion.py
+++ b/cidc-api/services/ingestion.py
@@ -153,4 +153,3 @@ def get_signed_url(object_name: str, method: str = "PUT", expiry_mins: int = 5) 
     url = blob.generate_signed_url(version="v4", expiration=expiration, method=method)
 
     return url
-

--- a/cidc-api/settings.py
+++ b/cidc-api/settings.py
@@ -37,6 +37,11 @@ AUTH0_CLIENT_ID = environ.get("AUTH0_CLIENT_ID")
 ALGORITHMS = ["RS256"]
 ## End Auth0 config
 
+## Configure GCS
+GOOGLE_UPLOAD_BUCKET = environ.get("GOOGLE_UPLOAD_BUCKET")
+# TODO: additional buckets for pipeline data etc.?
+## End GCS config
+
 ## Configure database
 POSTGRES_URI = environ.get("POSTGRES_URI")
 if TESTING:

--- a/cidc-api/settings.py
+++ b/cidc-api/settings.py
@@ -7,32 +7,37 @@ from models import Users, TrialMetadata
 
 load_dotenv()
 
+
+def get_secrets_manager(is_testing):
+    """Get a secrets manager based on whether the app is running in test mode"""
+    if is_testing:
+        from unittest.mock import MagicMock
+
+        # If we're testing, we shouldn't need access to secrets in GCS
+        return MagicMock()
+    else:
+        from secrets import CloudStorageSecretManager
+
+        secrets_bucket = environ.get("SECRETS_BUCKET_NAME")
+        return CloudStorageSecretManager(secrets_bucket)
+
+
+## Configure application environment
+ENV = environ.get("ENV", "staging")
+assert ENV in ("dev", "staging", "prod")
+DEBUG = ENV == "dev" and environ.get("DEBUG")
 TESTING = environ.get("TESTING") == "True"
+## End application environment config
 
-# Configure secrets manager
-if TESTING:
-    from unittest.mock import MagicMock
+secrets = get_secrets_manager(TESTING)
 
-    # If we're testing, we shouldn't need access to secrets in GCS
-    secrets = MagicMock()
-else:
-    from secrets import CloudStorageSecretManager
-
-    secrets_bucket = environ.get("SECRETS_BUCKET_NAME")
-    secrets = CloudStorageSecretManager(secrets_bucket)
-
-# Auth0 configuration
+## Configure Auth0
 AUTH0_DOMAIN = environ.get("AUTH0_DOMAIN")
 AUTH0_CLIENT_ID = environ.get("AUTH0_CLIENT_ID")
 ALGORITHMS = ["RS256"]
+## End Auth0 config
 
-# Deployment environment
-ENV = environ.get("ENV", "staging")
-assert ENV in ("dev", "staging", "prod")
-
-DEBUG = ENV == "dev" and environ.get("DEBUG")
-
-# Database configuration
+## Configure database
 POSTGRES_URI = environ.get("POSTGRES_URI")
 if TESTING:
     # Connect to the test database
@@ -73,8 +78,9 @@ elif not POSTGRES_URI:
 assert POSTGRES_URI
 SQLALCHEMY_DATABASE_URI = POSTGRES_URI
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+## End database config
 
-
+## Configure Eve REST API
 RESOURCE_METHODS = ["GET", "POST"]
 ITEM_METHODS = ["GET", "PUT", "PATCH"]
 
@@ -83,3 +89,4 @@ _domain_config = {
     "trial-metadata": ResourceConfig(TrialMetadata),
 }
 DOMAIN = DomainConfig(_domain_config).render()
+## End Eve REST API config

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,7 @@
+from typing import List
+
+
+def assert_same_elements(a: List, b: List):
+    """Check if `a` and `b` contain the same elements, raising an assertion error if not."""
+    assert len(a) == len(b)
+    assert set(a) == set(b)


### PR DESCRIPTION
Adds the endpoint `/ingestion/signed-upload-urls` that, given a request containing JSON specifying an upload "directory" and file names, returns a mapping of file names to signed upload URLs. This will allow a client (e.g., the cidc-cli) to upload directly to GCS using these URLs.