### PR TITLE
Store the full GCS URI for an uploaded file

### DIFF
--- a/cidc-api/services/ingestion.py
+++ b/cidc-api/services/ingestion.py
@@ -149,7 +149,7 @@ def upload():
         # Store the full path to GCS object for this file
         # in the url mapping to be sent back to the user.
         gcs_uri = f"{gcs_uri_prefix}/{local_path}"
-        url_mapping[local_path] = gcs_uri_prefix
+        url_mapping[local_path] = gcs_uri
 
     # Save the upload job to the database
     xlsx_bytes = xlsx_file.read()

--- a/tests/services/test_ingestion.py
+++ b/tests/services/test_ingestion.py
@@ -121,6 +121,7 @@ def test_upload(app_no_auth, wes_xlsx, test_user, monkeypatch):
     gcs_object_name = url_mapping[local_path]
     assert local_path in url_mapping
     assert gcs_object_name.startswith(gcs_prefix)
+    assert gcs_object_name.endswith(local_path)
 
     # Check that we tried to grant IAM upload access to gcs_object_name
     iam_args = (GOOGLE_UPLOAD_BUCKET, test_user.email)


### PR DESCRIPTION
A typo left uncaught by a test that should've been written 😞