### PR TITLE
Remove gcloud installation from Travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: "python"
 python:
   - "3.6"
-cache:
-  directories:
-    - $HOME/google-cloud-sdk/
 services:
   - postgresql
 addons:
@@ -11,31 +8,7 @@ addons:
 env:
   global:
     - PYTHONPATH=$PYTHONPATH:$(pwd)/cidc_api
-    - CLOUDSDK_CORE_DISABLE_PROMPTS=1
     - GOOGLE_APPLICATION_CREDENTIALS=$HOME/credentials.json
-    - GCLOUD_PROJECT_ID_STAGING=cidc-dfci-staging
-    - GCLOUD_PROJECT_ID_PROD=cidc-dfci
-before_install:
-  # Install and configure the gcloud SDK. Values for these environment 
-  # variables must be set in the Travis CI console for this to work:
-  #   GCLOUD_SERVICE_ACCOUNT_JSON_STAGING
-  #     -> base64-encoded service account JSON credentials for the staging project
-  #   GCLOUD_SERVICE_ACCOUNT_JSON_PROD 
-  #     -> base64-encoded service account JSON credentials for the production project
-  - if [ ! -d ${HOME}/google-cloud-sdk/bin ]; then
-      rm -rf $HOME/google-cloud-sdk;
-      curl https://sdk.cloud.google.com | bash > /dev/null;
-    fi
-  - source $HOME/google-cloud-sdk/path.bash.inc
-  - if [ "$TRAVIS_BRANCH" = production ]; then
-      gcloud config set project $GCLOUD_PROJECT_ID_PROD;
-      export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_PROD";
-    else
-      gcloud config set project $GCLOUD_PROJECT_ID_STAGING;
-      export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING";
-    fi
-  - echo "$GCLOUD_SERVICE_ACCOUNT_JSON" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
-  - gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
 install:
   - pip install -r requirements.txt -r requirements.dev.txt
 before_script:
@@ -46,16 +19,22 @@ script:
   - pytest
   - black --check cidc_api --target-version=py36
 
+before_deploy:
+  - if [ "$TRAVIS_BRANCH" = production ]; then
+      echo "$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
+    else
+      echo "$GCLOUD_SERVICE_ACCOUNT_JSON_PROD" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
+    fi
 deploy:
   - provider: gae
     keyfile: $GOOGLE_APPLICATION_CREDENTIALS
-    project: $GCLOUD_PROJECT_ID_STAGING
+    project: cidc-dfci-staging
     config: app.staging.yaml
     on:
       branch: master
   - provider: gae
     keyfile: $GOOGLE_APPLICATION_CREDENTIALS
-    project: $GCLOUD_PROJECT_ID_PROD
+    project: cidc-dfci
     config: app.prod.yaml
     on:
       branch: production


### PR DESCRIPTION
The Travis pipeline doesn't use the Google Cloud SDK installation directly, so this PR removes it.