### PR TITLE
Update cidc_schemas dependency and test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ werkzeug==0.15.4
 gunicorn
 
 # CIMAC-CIDC modules
-git+https://github.com/cimac-cidc/cidc-schemas@release
+cidc-schemas==0.1.1

--- a/tests/services/test_ingestion.py
+++ b/tests/services/test_ingestion.py
@@ -117,7 +117,7 @@ def test_upload(app_no_auth, wes_xlsx, test_user, monkeypatch):
     # We expect local_path to map to a gcs object name with gcs_prefix
     # based on the contents of wes_xlsx.
     local_path = "read_group_map.txt"
-    gcs_prefix = "10021/Patient_1/sample_1/aliquot_2/wes_read_group.txt/"
+    gcs_prefix = "10021/Patient 1/sample 1/aliquot 2/wes_read_group.txt/"
     gcs_object_name = url_mapping[local_path]
     assert local_path in url_mapping
     assert gcs_object_name.startswith(gcs_prefix)


### PR DESCRIPTION
Now that cidc-schemas is [hosted on PyPI](https://pypi.org/project/cidc-schemas/), we should use the PyPI deployment rather than the version from github.