### PR TITLE
Prevent dangerous user creation

### DIFF
--- a/cidc_api/auth.py
+++ b/cidc_api/auth.py
@@ -56,7 +56,7 @@ class BearerAuth(TokenAuth):
             _request_ctx_stack.top.current_user = Users(email=profile["email"])
 
             # User is only authorized to create themself.
-            if resource == "users" and method == "POST":
+            if resource == "new_users" and method == "POST":
                 return True
 
             raise Unauthorized(f'{profile["email"]} is not registered.')

--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -1,4 +1,5 @@
 from os import environ
+from copy import deepcopy
 
 from eve_sqlalchemy.config import DomainConfig, ResourceConfig
 from dotenv import load_dotenv
@@ -57,6 +58,12 @@ _domain_config = {
 }
 
 _domain = DomainConfig(_domain_config).render()
+
+# New users should not be created with roles or approval
+_new_users = deepcopy(_domain["users"])
+del _new_users["schema"]["role"]
+del _new_users["schema"]["approval_date"]
+_domain["new_users"] = _new_users
 
 admins_only = {"allowed_roles": ["cidc-admin"], "allowed_item_roles": ["cidc-admin"]}
 

--- a/cidc_api/services/users.py
+++ b/cidc_api/services/users.py
@@ -6,7 +6,7 @@ from werkzeug.exceptions import Unauthorized, BadRequest
 
 
 def register_users_hooks(app: Eve):
-    app.on_pre_POST_users += enforce_self_creation
+    app.on_pre_POST_new_users += enforce_self_creation
 
 
 def enforce_self_creation(request: Request):

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -1,4 +1,4 @@
-USERS = "users"
+NEW_USERS = "new_users"
 
 EMAIL = "test@email.com"
 AUTH_HEADER = {"Authorization": "Bearer foo"}
@@ -18,10 +18,10 @@ def test_enforce_self_creation(app, db, monkeypatch):
     # If there's a mismatch between the requesting user's email
     # and the email of the user to create, the user should not be created
     other_profile = {"email": "foo@bar.org"}
-    response = client.post(USERS, json=other_profile, headers=AUTH_HEADER)
+    response = client.post(NEW_USERS, json=other_profile, headers=AUTH_HEADER)
     assert response.status_code == 401
     assert "not authorized to create use" in response.json["_error"]["message"]
 
     # Self-creation should work just fine
-    response = client.post(USERS, json=profile, headers=AUTH_HEADER)
+    response = client.post(NEW_USERS, json=profile, headers=AUTH_HEADER)
     assert response.status_code == 201  # Created

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -175,7 +175,7 @@ def test_role_auth(bearer_auth, app, db):
             bearer_auth.role_auth(profile, [], "users", "GET")
 
         # Unregistered user should be able to POST users
-        assert bearer_auth.role_auth(profile, [], "users", "POST")
+        assert bearer_auth.role_auth(profile, [], "new_users", "POST")
 
     # Add the user to the db but don't approve yet
     Users.create(profile)
@@ -183,7 +183,7 @@ def test_role_auth(bearer_auth, app, db):
     with app.test_request_context():
         # Unapproved user isn't authorized to do anything
         with pytest.raises(Unauthorized, match="pending approval"):
-            bearer_auth.role_auth(profile, [], "users", "POST")
+            bearer_auth.role_auth(profile, [], "new_users", "POST")
 
         # Give the user a role but don't approve them
         db.query(Users).filter_by(email=EMAIL).update(dict(role="cimac-user"))
@@ -191,7 +191,7 @@ def test_role_auth(bearer_auth, app, db):
 
         # Unapproved user *with an authorized role* still shouldn't be authorized
         with pytest.raises(Unauthorized, match="pending approval"):
-            bearer_auth.role_auth(profile, ["cimac-user"], "users", "POST")
+            bearer_auth.role_auth(profile, ["cimac-user"], "new_users", "POST")
 
     # Approve the user
     db.query(Users).filter_by(email=EMAIL).update(dict(approval_date=datetime.now()))

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,0 +1,24 @@
+"""Test constraints enforced by the Eve DOMAIN schema"""
+
+from datetime import datetime
+
+from .test_models import db_test
+
+EMAIL = "test@email.com"
+
+
+@db_test
+def test_new_users_POST(app_no_auth, db):
+    """Check that you can't create a new use with a role or approval date"""
+    client = app_no_auth.test_client()
+
+    # Someone malicious tries to create a new user for themselves with admin access
+    user_with_role = {"email": EMAIL, "role": "cidc-admin"}
+
+    response = client.post("/new_users", json=user_with_role)
+    assert response.status_code == 422  # Unprocessable Entity
+
+    # Someone malicious tries to create a new user for themselves with approval
+    user_with_approval = {"email": EMAIL, "approval_date": datetime.now()}
+    assert response.status_code == 422
+


### PR DESCRIPTION
This PR prevents an API client from creating a new user with an arbitrary role or with an immediately-approved account.