### PR TITLE
User registration fixes

### DIFF
--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -7,6 +7,7 @@ from eve_sqlalchemy.validation import ValidatorSQL
 from eve_swagger import swagger
 from flask import jsonify
 from flask_migrate import Migrate, upgrade
+from flask_cors import CORS
 
 from models import BaseModel
 from auth import BearerAuth
@@ -18,6 +19,10 @@ MIGRATIONS = join(ABSPATH, "..", "migrations")
 
 # Instantiate the Eve app
 app = Eve(auth=BearerAuth, data=SQL, validator=ValidatorSQL, settings=SETTINGS)
+
+# Enable CORS
+# TODO: be more selective about which domains can make requests
+CORS(app)
 
 # Register custom services
 register_services(app)

--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -22,7 +22,7 @@ app = Eve(auth=BearerAuth, data=SQL, validator=ValidatorSQL, settings=SETTINGS)
 
 # Enable CORS
 # TODO: be more selective about which domains can make requests
-CORS(app)
+CORS(app, resources={r"*": {"origins": "*"}})
 
 # Register custom services
 register_services(app)

--- a/cidc_api/auth.py
+++ b/cidc_api/auth.py
@@ -63,7 +63,11 @@ class BearerAuth(TokenAuth):
 
         # User is registered but not yet approved.
         if not user.approval_date:
-            # Unapproved users are not authorized to do anything.
+            # Unapproved users are not authorized to do anything but access their
+            # account info.
+            if resource == "users" and method == "GET":
+                return True
+
             raise Unauthorized(
                 f'{profile["email"]}\'s registration is pending approval'
             )

--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -59,15 +59,15 @@ _domain_config = {
 
 _domain = DomainConfig(_domain_config).render()
 
-# New users should not be created with roles or approval
+# New users have different restrictions than created users
 _new_users = deepcopy(_domain["users"])
 del _new_users["schema"]["role"]
 del _new_users["schema"]["approval_date"]
+_new_users["item_methods"] = []
+_new_users["resource methods"] = ["POST"]
 _domain["new_users"] = _new_users
 
 admins_only = {"allowed_roles": ["cidc-admin"], "allowed_item_roles": ["cidc-admin"]}
-
-_domain["users"].update(admins_only)
 _domain["permissions"].update(admins_only)
 
 DOMAIN = _domain

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -57,6 +57,15 @@ class CommonColumns(BaseModel):
     _created = Column(DateTime, default=func.now())
     _updated = Column(DateTime, default=func.now(), onupdate=func.now())
     _etag = Column(String(40))
+    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
+
+    @classmethod
+    @with_default_session
+    def find_by_id(cls, id: int, session: Session = None):
+        """Find the record with this id"""
+        assert session
+
+        return session.query(cls).get(id)
 
 
 ORGS = ["CIDC", "DFCI", "ICAHN", "STANFORD", "ANDERSON"]
@@ -75,7 +84,6 @@ ASSAYS = ["cytof", "mif", "micsss", "olink", "rna expression", "wes"]
 class Users(CommonColumns):
     __tablename__ = "users"
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
     email = Column(String, unique=True, nullable=False, index=True)
     first_n = Column(String)
     last_n = Column(String)
@@ -122,8 +130,6 @@ class Users(CommonColumns):
 class Permissions(CommonColumns):
     __tablename__ = "permissions"
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
-
     # If user who granted this permission is deleted, this permission will be deleted.
     # TODO: is this what we want?
     granted_by_user = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"))
@@ -143,7 +149,6 @@ class Permissions(CommonColumns):
 
 class TrialMetadata(CommonColumns):
     __tablename__ = "trial_metadata"
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
     # The CIMAC-determined trial id
     trial_id = Column(String, unique=True, nullable=False, index=True)
     metadata_json = Column(JSONB, nullable=False)
@@ -185,8 +190,6 @@ STATUSES = ["started", "completed", "errored"]
 
 class UploadJobs(CommonColumns):
     __tablename__ = "upload_jobs"
-
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
     # The current status of the upload job
     status = Column(Enum(*STATUSES, name="job_statuses"), nullable=False)
     # The object names for the files to be uploaded
@@ -223,11 +226,3 @@ class UploadJobs(CommonColumns):
         session.commit()
 
         return job
-
-    @staticmethod
-    @with_default_session
-    def find_by_id(id: int, session: Session = None):
-        """Find the record with this id"""
-        assert session
-
-        return session.query(UploadJobs).get(id)

--- a/cidc_api/services/users.py
+++ b/cidc_api/services/users.py
@@ -19,7 +19,7 @@ from models import Users
 
 def register_users_hooks(app: Eve):
     app.on_pre_POST_new_users += enforce_self_creation
-    app.on_pre_GET_users += filter_nonadmin_lookup
+    app.on_pre_GET_users += filter_user_lookup
     app.on_pre_PATCH_users += add_approval_date
 
 
@@ -42,7 +42,7 @@ def enforce_self_creation(request: Request):
         )
 
 
-def filter_nonadmin_lookup(request: Request, lookup: dict):
+def filter_user_lookup(request: Request, lookup: dict):
     """
     Ensure that non-admin users can only look up their own account info.
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 eve-sqlalchemy==0.7.0
 eve-swagger==0.0.11
-flask-cors==
+flask-cors==3.0.8
 flask-migrate==2.5.2
 python-dotenv==0.10.3
 requests==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 eve-sqlalchemy==0.7.0
 eve-swagger==0.0.11
+flask-cors==
 flask-migrate==2.5.2
 python-dotenv==0.10.3
 requests==2.22.0

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -1,23 +1,25 @@
 NEW_USERS = "new_users"
+USERS = "users"
 
 EMAIL = "test@email.com"
 AUTH_HEADER = {"Authorization": "Bearer foo"}
 
+profile = {"email": EMAIL}
+other_profile = {"email": "foo@bar.org"}
+
+
+def fake_token_auth(*args):
+    return profile
+
 
 def test_enforce_self_creation(app, db, monkeypatch):
     """Check that users can only create themselves"""
-    profile = {"email": EMAIL}
-
-    def fake_token_auth(*args):
-        return profile
-
     monkeypatch.setattr(app.auth, "token_auth", fake_token_auth)
 
     client = app.test_client()
 
     # If there's a mismatch between the requesting user's email
     # and the email of the user to create, the user should not be created
-    other_profile = {"email": "foo@bar.org"}
     response = client.post(NEW_USERS, json=other_profile, headers=AUTH_HEADER)
     assert response.status_code == 401
     assert "not authorized to create use" in response.json["_error"]["message"]
@@ -25,3 +27,36 @@ def test_enforce_self_creation(app, db, monkeypatch):
     # Self-creation should work just fine
     response = client.post(NEW_USERS, json=profile, headers=AUTH_HEADER)
     assert response.status_code == 201  # Created
+
+
+def test_prevent_unregistered_lookup(app, db, monkeypatch):
+    """Check that unregistered users can only lookup themselves"""
+    monkeypatch.setattr(app.auth, "token_auth", fake_token_auth)
+
+    client = app.test_client()
+
+    # Create two new users
+    client.post(NEW_USERS, json=profile, headers=AUTH_HEADER)
+    client.post(NEW_USERS, json=other_profile, headers=AUTH_HEADER)
+
+    # Check that a user can only look themselves up
+    response = client.get(USERS, headers=AUTH_HEADER)
+    assert response.status_code == 200
+    users = response.json["_items"]
+    assert len(users) == 1
+    assert users[0]["email"] == profile["email"]
+
+    filtered_response = client.get(
+        USERS + '?where{"email": "%s"}' % EMAIL, headers=AUTH_HEADER
+    )
+    assert filtered_response.status_code == 200
+    assert filtered_response.json["_items"] == response.json["_items"]
+
+    # If the user tries to look up someone else, they get nothing back
+    response = client.get(
+        USERS + '?where={"email": "%s"}' % other_profile["email"], headers=AUTH_HEADER
+    )
+    assert response.status_code == 200
+    assert len(response.json["_items"]) == 0
+
+    # TODO: test that admins can still list all users


### PR DESCRIPTION
Resolves some issues with user registration encountered while preparing https://github.com/CIMAC-CIDC/cidc-ui/pull/85.

Fixes:
* Enable CORS to prevent related errors while testing local API instance with a local UI instance.
* New users should not be able to set the `role` or `approval_date` field when creating themselves for the first time. The `new_users` resource schema sets these restrictions.    

Additions:
* Non-admin users can only read their own account info. Admins are the only ones who can list all users.
* When a new user's role is set for the first time, their `approval_date` is also set using a pre-PATCH hook.