### PR TITLE
Explicitly download App Engine service account credentials

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flask-migrate==2.5.2
 python-dotenv==0.10.3
 requests==2.22.0
 six==1.12.0
-google-cloud-storage==1.16.1
+google-cloud-storage==1.18.0
 google-cloud-pubsub==0.42.1
 python-jose==3.0.1
 psycopg2-binary==2.8.3


### PR DESCRIPTION
Without this, the `insert_download_url` hook throws the following error while running in an App Engine deployment:
```
you need a private key to sign credentials.the credentials you are currently using 
<class 'google.auth.compute_engine.credentials.Credentials'> just contains a token. 
see https://google-cloud-python.readthedocs.io/en/latest/core/auth.html?highlight=authentication#setting-up-a-service-account 
for more details.
```
Explicitly downloading the service account credentials and setting `GOOGLE_APPLICATION_CREDENTIALS` clears this error up.