### PR TITLE
Disable browser caching of results

### DIFF
--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -67,5 +67,6 @@ SCHEMA_TO_HINT = dict((schema, hint) for hint, schema in HINT_TO_SCHEMA.items())
 ## Configure Eve REST API
 RESOURCE_METHODS = ["GET", "POST"]
 ITEM_METHODS = ["GET", "PUT", "PATCH"]
+CACHE_CONTROL = "no-cache"
 DOMAIN = get_DOMAIN()
 ## End Eve REST API config


### PR DESCRIPTION
We may want to get more clever about this going forward by, e.g., setting cache control on the resource level, but for now let's just disable it to avoid inconsistencies.