### PR TITLE
Update excel template validation functionality

### DIFF
--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -55,15 +55,6 @@ SQLALCHEMY_DATABASE_URI = db.get_sqlachemy_database_uri(TESTING)
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 ## End database config
 
-## Configure application constants
-SUPPORTED_ASSAYS = ["wes"]
-HINT_TO_SCHEMA = {
-    "wes": "templates/metadata/wes_template.json",
-    "pbmc": "templates/manifests/pbmc_template.json",
-}
-SCHEMA_TO_HINT = dict((schema, hint) for hint, schema in HINT_TO_SCHEMA.items())
-## End configure constants
-
 ## Configure Eve REST API
 RESOURCE_METHODS = ["GET", "POST"]
 ITEM_METHODS = ["GET", "PUT", "PATCH"]

--- a/cidc_api/gcloud_client.py
+++ b/cidc_api/gcloud_client.py
@@ -15,6 +15,7 @@ from config.settings import (
     GOOGLE_CLOUD_PROJECT,
     GOOGLE_EMAILS_TOPIC,
     TESTING,
+    ENV,
 )
 
 
@@ -103,7 +104,7 @@ def publish_upload_success(job_id: int):
 def send_email(to_emails: List[str], subject: str, html_content: str):
     """Publish an email-to-send to the emails topic."""
     # Don't actually send an email if this is a test
-    if TESTING:
+    if TESTING or ENV == "dev":
         print(f"Would send email with subject '{subject}' to {to_emails}")
         return
 

--- a/cidc_api/services/info.py
+++ b/cidc_api/services/info.py
@@ -1,12 +1,21 @@
 """Endpoints providing info related to this API"""
 from flask import Blueprint, jsonify
 
-from config.settings import SUPPORTED_ASSAYS
+from cidc_schemas.template import _TEMPLATE_PATH_MAP
 
 info_api = Blueprint("info", __name__, url_prefix="/info")
+
+assay_list = [k for k, v in _TEMPLATE_PATH_MAP.items() if "metadata" in v]
+manifest_list = [k for k, v in _TEMPLATE_PATH_MAP.items() if "manifests" in v]
 
 
 @info_api.route("assays", methods=["GET"])
 def assays():
     """List all supported assays"""
-    return jsonify(SUPPORTED_ASSAYS)
+    return jsonify(assay_list)
+
+
+@info_api.route("manifests", methods=["GET"])
+def manifests():
+    """List all supported manifests"""
+    return jsonify(manifest_list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ werkzeug==0.15.4
 gunicorn
 
 # CIMAC-CIDC modules
-cidc-schemas==0.1.4
+cidc-schemas==0.1.6

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -2,8 +2,16 @@ INFO_ENDPOINT = "/info"
 
 
 def test_info_assays(app_no_auth):
-    """Check that the /info/assays endpoints returns a list of assays"""
+    """Check that the /info/assays endpoint returns a list of assays"""
     client = app_no_auth.test_client()
     res = client.get(f"{INFO_ENDPOINT}/assays")
     assert type(res.json) == list
     assert "wes" in res.json
+
+
+def test_info_manifests(app_no_auth):
+    """Check that the /info/manifests endpoint returns a list of manifests"""
+    client = app_no_auth.test_client()
+    res = client.get(f"{INFO_ENDPOINT}/manifests")
+    assert type(res.json) == list
+    assert "pbmc" in res.json

--- a/tests/services/test_ingestion.py
+++ b/tests/services/test_ingestion.py
@@ -56,7 +56,7 @@ UPLOAD = "/ingestion/upload"
 def test_validate_valid_template(app_no_auth, valid_xlsx):
     """Ensure that the validation endpoint returns no errors for a known-valid .xlsx file"""
     client = app_no_auth.test_client()
-    data = form_data("pbmc.xlsx", valid_xlsx, "templates/manifests/pbmc_template.json")
+    data = form_data("pbmc.xlsx", valid_xlsx, "pbmc")
     res = client.post(VALIDATE, data=data)
     assert res.status_code == 200
     assert res.json["errors"] == []
@@ -65,9 +65,7 @@ def test_validate_valid_template(app_no_auth, valid_xlsx):
 def test_validate_invalid_template(app_no_auth, invalid_xlsx):
     """Ensure that the validation endpoint returns errors for a known-invalid .xlsx file"""
     client = app_no_auth.test_client()
-    data = form_data(
-        "pbmc.xlsx", invalid_xlsx, "templates/manifests/pbmc_template.json"
-    )
+    data = form_data("pbmc.xlsx", invalid_xlsx, "pbmc")
     res = client.post(VALIDATE, data=data)
     assert res.status_code == 200
     assert len(res.json["errors"]) > 0
@@ -89,7 +87,7 @@ def test_validate_invalid_template(app_no_auth, invalid_xlsx):
             VALIDATE,
             form_data("test.xlsx", schema="foo/bar"),
             BadRequest,
-            "schema with id foo/bar",
+            "Unknown template type foo/bar",
         ],
     ],
 )


### PR DESCRIPTION
Some template validation improvements based on updates to `cidc-schemas`:
* Removes hardcoded `HINT_TO_SCHEMA` in favor of using the `cidc_schemas.templates._TEMPLATE_PATH_MAP`
* Adds endpoints for listing supported assays and manifest template types. Not sure if these will be useful, but we might want them for the CLI + UI.