### PR TITLE
Add gcloud installation back to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,11 @@ script:
 
 before_deploy:
   - if [ "$TRAVIS_BRANCH" = production ]; then
-      echo "$GCLOUD_SERVICE_ACCOUNT_JSON_PROD" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS;
+    echo "$GCLOUD_SERVICE_ACCOUNT_JSON_PROD" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS;
     else
-      echo "$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS;
+    echo "$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS;
     fi
+  - sh .travis/install_gcloud.sh
 deploy:
   - provider: script
     # we need `beta` for the `--no-cache` flag, which disables dependency caching

--- a/.travis/install_gcloud.sh
+++ b/.travis/install_gcloud.sh
@@ -1,0 +1,24 @@
+# !/usr/bin/bash
+#
+# Install the Google Cloud SDK. Values for these environment 
+# variables must be set in the Travis CI console for this to work:
+#   GCLOUD_SERVICE_ACCOUNT_JSON_STAGING
+#     -> base64-encoded service account JSON credentials for the staging project
+#   GCLOUD_SERVICE_ACCOUNT_JSON_PROD 
+#     -> base64-encoded service account JSON credentials for the production project
+
+if [ ! -d ${HOME}/google-cloud-sdk/bin ]; then
+    rm -rf $HOME/google-cloud-sdk;
+    curl https://sdk.cloud.google.com | bash > /dev/null;
+fi
+source $HOME/google-cloud-sdk/path.bash.inc
+if [ "$TRAVIS_BRANCH" = production ]; then
+    gcloud config set project $GCLOUD_PROJECT_ID_PROD;
+    export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_PROD";
+else
+    gcloud config set project $GCLOUD_PROJECT_ID_STAGING;
+    export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING";
+fi
+echo "$GCLOUD_SERVICE_ACCOUNT_JSON" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
+gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+gcloud components update


### PR DESCRIPTION
Now that the `deploy` stage uses a script provider, we need to add back explicit gcloud downloads to the travis pipeline to get deployments working again.