### PR TITLE
Add `/users/self` endpoint and allow users to read own permissions

### DIFF
--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -111,7 +111,7 @@ def get_DOMAIN() -> dict:
 
     # Restrict operations on the 'permissions' resource:
     # * Only admins can write or update 'permissions'
-    # * All users can read permissions, but the results will be filtered by
+    # * All users can list the 'permissions' resource, but the results will be filtered by
     #   services.permissions.update_permission_filters to only include their permissions
     domain["permissions"]["allowed_write_roles"] = [CIDCRole.ADMIN.value]
     domain["permissions"]["allowed_item_roles"] = [CIDCRole.ADMIN.value]

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -105,11 +105,16 @@ def get_DOMAIN() -> dict:
     domain["new_users"]["resource_methods"] = ["POST"]
 
     # Restrict operations on resources that only admins should be able to access
-    for resource in ["users", "permissions", "trial_metadata"]:
+    for resource in ["users", "trial_metadata"]:
         domain[resource]["allowed_roles"] = [CIDCRole.ADMIN.value]
         domain[resource]["allowed_item_roles"] = [CIDCRole.ADMIN.value]
 
-    # Make permissions deletable by admins
+    # Restrict operations on the 'permissions' resource:
+    # * Only admins can write or update 'permissions'
+    # * All users can read permissions, but the results will be filtered by
+    #   services.permissions.update_permission_filters to only include their permissions
+    domain["permissions"]["allowed_write_roles"] = [CIDCRole.ADMIN.value]
+    domain["permissions"]["allowed_item_roles"] = [CIDCRole.ADMIN.value]
     domain["permissions"]["item_methods"] = ["GET", "DELETE", "PATCH"]
 
     # Restrict operations on the 'assay_uploads' resource:

--- a/cidc_api/services/__init__.py
+++ b/cidc_api/services/__init__.py
@@ -4,7 +4,7 @@ from eve import Eve
 from .files import register_files_hooks
 from .info import info_api
 from .ingestion import ingestion_api, register_ingestion_hooks
-from .users import register_users_hooks
+from .users import users_api, register_users_hooks
 
 
 def register_services(app: Eve):
@@ -12,6 +12,7 @@ def register_services(app: Eve):
     # Blueprints
     app.register_blueprint(ingestion_api)
     app.register_blueprint(info_api)
+    app.register_blueprint(users_api)
 
     # Hooks
     register_ingestion_hooks(app)

--- a/cidc_api/services/__init__.py
+++ b/cidc_api/services/__init__.py
@@ -5,6 +5,7 @@ from .files import register_files_hooks
 from .info import info_api
 from .ingestion import ingestion_api, register_ingestion_hooks
 from .users import users_api, register_users_hooks
+from .permissions import register_permissions_hooks
 
 
 def register_services(app: Eve):
@@ -18,3 +19,4 @@ def register_services(app: Eve):
     register_ingestion_hooks(app)
     register_users_hooks(app)
     register_files_hooks(app)
+    register_permissions_hooks(app)

--- a/cidc_api/services/permissions.py
+++ b/cidc_api/services/permissions.py
@@ -1,0 +1,25 @@
+from eve import Eve
+
+from flask import _request_ctx_stack, Blueprint, Request
+
+from models import CIDCRole
+
+
+def register_permissions_hooks(app: Eve):
+    app.on_pre_GET_permissions = update_permissions_filters
+
+
+def update_permissions_filters(request: Request, lookup: dict):
+    """
+    Update a GET request to the 'permissions' resource to include only
+    the current user's permissions, unless the user is an admin.
+    """
+    user = _request_ctx_stack.top.current_user
+
+    # Admins can get all permissions
+    if user.role == CIDCRole.ADMIN.value:
+        return
+
+    # Otherwise, only include permissions granted to this user
+    lookup["to_user"] = user.id
+

--- a/cidc_api/services/permissions.py
+++ b/cidc_api/services/permissions.py
@@ -22,4 +22,3 @@ def update_permissions_filters(request: Request, lookup: dict):
 
     # Otherwise, only include permissions granted to this user
     lookup["to_user"] = user.id
-

--- a/cidc_api/services/users.py
+++ b/cidc_api/services/users.py
@@ -24,11 +24,11 @@ users_api = Blueprint("users", __name__, url_prefix="/users")
 @users_api.route("/self", methods=["GET"])
 @requires_auth("users.self")
 def get_self():
-    jsonish_user = _request_ctx_stack.top.current_user.__dict__
-    # Don't try to serialize SQLAlchemy state data
-    if "_sa_instance_state" in jsonish_user:
-        del jsonish_user["_sa_instance_state"]
-    return jsonify(jsonish_user)
+    user = _request_ctx_stack.top.current_user
+    # Extract fields from the database record
+    column_names = user.__table__.columns.keys()
+    user_dict = dict((col, getattr(user, col)) for col in column_names)
+    return jsonify(user_dict)
 
 
 def register_users_hooks(app: Eve):

--- a/tests/services/test_permissions.py
+++ b/tests/services/test_permissions.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock
+from datetime import datetime
+
+from cidc_api.models import Users, Permissions, TrialMetadata, CIDCRole
+
+from ..test_models import db_test
+from ..conftest import TEST_EMAIL
+
+
+def test_update_permissions_filters(app, db, monkeypatch):
+    """Check that permissions are filtered for non-admin users"""
+    payload = {"email": TEST_EMAIL}
+
+    def token_auth(*args):
+        return payload
+
+    monkeypatch.setattr(app.auth, "token_auth", token_auth)
+
+    with app.app_context():
+        # Create users
+        user = Users.create(payload)
+        user.role = CIDCRole.CIMAC_USER.value
+        user.approval_date = datetime.now()
+        other_user = Users.create({"email": TEST_EMAIL + ".org"})
+
+        user_id = user.id
+
+        # Create trial
+        trial_id = "foo"
+        TrialMetadata.create(trial_id, {})
+
+        # Create permissions
+        def create_permission(uid, assay):
+            db.add(
+                Permissions(
+                    granted_by_user=uid,
+                    granted_to_user=uid,
+                    trial_id=trial_id,
+                    assay_type=assay,
+                )
+            )
+
+        create_permission(user.id, "wes")
+        create_permission(user.id, "olink")
+        create_permission(other_user.id, "olink")
+
+        db.commit()
+
+    client = app.test_client()
+
+    res = client.get("permissions", headers={"Authorization": "Bearer adlkjadsfl"})
+    assert res.status_code == 200
+    assert len(res.json["_items"]) == 2
+    for perm in res.json["_items"]:
+        assert perm["to_user"] == user_id
+
+    # Update user's role to admin
+    with app.app_context():
+        user = Users.find_by_id(user_id)
+        user.role = CIDCRole.ADMIN.value
+        db.commit()
+
+    # Check that user can now read all permissions
+    res = client.get("permissions", headers={"Authorization": "Bearer adlkjadsfl"})
+    assert res.status_code == 200
+    assert len(res.json["_items"]) == 3

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -41,8 +41,13 @@ def test_filter_user_lookups(app, db, monkeypatch):
 
     # Create two new users
     with app.app_context():
-        Users.create(profile)
-        Users.create(other_profile)
+        user1 = Users.create(profile)
+        user1.role = "cimac-user"
+        user1.approval_date = datetime.now()
+        user2 = Users.create(other_profile)
+        user2.role = "cimac-user"
+        user2.approval_date = datetime.now()
+        db.commit()
 
     # Check that a user can only look themselves up
     response = client.get(USERS, headers=AUTH_HEADER)

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -33,51 +33,29 @@ def test_enforce_self_creation(app, db, monkeypatch):
     assert response.status_code == 201  # Created
 
 
-def test_filter_user_lookups(app, db, monkeypatch):
-    """Check user GET-request role-based filtering"""
+def test_get_self(app, db, monkeypatch):
+    """Check that a low-privilege user can get their own account info"""
     monkeypatch.setattr(app.auth, "token_auth", fake_token_auth)
 
     client = app.test_client()
 
     # Create two new users
     with app.app_context():
-        user1 = Users.create(profile)
-        user1.role = "cimac-user"
-        user1.approval_date = datetime.now()
-        user2 = Users.create(other_profile)
-        user2.role = "cimac-user"
-        user2.approval_date = datetime.now()
+        user = Users.create(profile)
+        user.role = "cimac-user"
+        user.approval_date = datetime.now()
+        other_user = Users.create(other_profile)
         db.commit()
 
-    # Check that a user can only look themselves up
+    # Check that a low-privs user can look themselves up at the users/self endpoint
+    response = client.get(USERS + "/self", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    user = response.json
+    assert user["email"] == profile["email"]
+
+    # Check that a low-privs user cannot look up other users
     response = client.get(USERS, headers=AUTH_HEADER)
-    assert response.status_code == 200
-    users = response.json["_items"]
-    assert len(users) == 1
-    assert users[0]["email"] == profile["email"]
-
-    filtered_response = client.get(
-        USERS + '?where{"email": "%s"}' % EMAIL, headers=AUTH_HEADER
-    )
-    assert filtered_response.status_code == 200
-    assert filtered_response.json["_items"] == response.json["_items"]
-
-    # If the user tries to look up someone else, they get nothing back
-    response = client.get(
-        USERS + '?where={"email": "%s"}' % other_profile["email"], headers=AUTH_HEADER
-    )
-    assert response.status_code == 200
-    assert len(response.json["_items"]) == 0
-
-    # Make a user an admin
-    with app.app_context():
-        db.query(Users).filter_by(email=EMAIL).update({"role": CIDCRole.ADMIN.value})
-        db.commit()
-
-    # Admins should be able to list all users
-    response = client.get(USERS, headers=AUTH_HEADER)
-    assert response.status_code == 200
-    assert len(response.json["_items"]) == 2
+    assert response.status_code == 401
 
 
 def test_add_approval_date(app, db, monkeypatch):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -285,11 +285,14 @@ def test_rbac(monkeypatch, app, db):
         res = client.get("downloadable_files", headers=HEADER)
         assert res.status_code == 200
 
+        # Everyone can read permissions (though the results will be filtered)
+        res = client.get("permissions", headers=HEADER)
+        assert res.status_code == 200
+
         # Test admin-restricted GETs
         admin_only_GETable = [
             "users",
             "trial_metadata",
-            "permissions",
             "assay_uploads",
             "manifest_uploads",
         ]


### PR DESCRIPTION
Since only `cidc-admins` can access the `users` resource according to current RBAC configs, add a `/users/self` endpoint that allows an authenticated user with any role to access their own profile information. Also, remove the now-defunct `filter_user_lookups` hook.

Also, adds `services.permissions.update_permissions_filters` to allow non-admin users to read their own permissions.