### PR TITLE
Restrict uploads based on permissions

### DIFF
--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -261,9 +261,11 @@ class Permissions(CommonColumns):
         user: Users, trial_id: str, type_: str, session: Session
     ):
         """Check if a Permissions record exists for the given user, trial, and type."""
-        return session.query(Permissions).filter_by(
-            granted_to_user=user.id, trial_id=trial_id, assay_type=type_
-        ).first()
+        return (
+            session.query(Permissions)
+            .filter_by(granted_to_user=user.id, trial_id=trial_id, assay_type=type_)
+            .first()
+        )
 
 
 class TrialMetadata(CommonColumns):

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -255,6 +255,16 @@ class Permissions(CommonColumns):
         """Find all Permissions granted to the given user."""
         return session.query(Permissions).filter_by(granted_to_user=user.id).all()
 
+    @staticmethod
+    @with_default_session
+    def find_for_user_trial_type(
+        user: Users, trial_id: str, type_: str, session: Session
+    ):
+        """Check if a Permissions record exists for the given user, trial, and type."""
+        return session.query(Permissions).filter_by(
+            granted_to_user=user.id, trial_id=trial_id, assay_type=type_
+        ).first()
+
 
 class TrialMetadata(CommonColumns):
     # TODO: split up metadata_json into separate `manifest`, `assays`, and `trial_info` fields on this table.


### PR DESCRIPTION
Now, NCI uploaders can only upload trial / manifest combos for which they have permission, and CIMAC uploaders can only upload trial / assay combos for which they have permission.