### PR TITLE
Allow admins to upload any assay or manifest

### DIFF
--- a/cidc_api/services/ingestion.py
+++ b/cidc_api/services/ingestion.py
@@ -145,7 +145,8 @@ def check_permissions(user, trial_id, template_type):
     If no permission exists for this user-trial-template_type trio, raise a 401.
     """
     perm = Permissions.find_for_user_trial_type(user, trial_id, template_type)
-    if not perm:
+    print(user.role)
+    if not perm and user.role != CIDCRole.ADMIN.value:
         if not TrialMetadata.find_by_trial_id(trial_id):
             raise BadRequest(
                 f"Trial with {prism.PROTOCOL_ID_FIELD_NAME}={trial_id} not found."

--- a/cidc_api/services/ingestion.py
+++ b/cidc_api/services/ingestion.py
@@ -145,7 +145,6 @@ def check_permissions(user, trial_id, template_type):
     If no permission exists for this user-trial-template_type trio, raise a 401.
     """
     perm = Permissions.find_for_user_trial_type(user, trial_id, template_type)
-    print(user.role)
     if not perm and user.role != CIDCRole.ADMIN.value:
         if not TrialMetadata.find_by_trial_id(trial_id):
             raise BadRequest(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ test_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(test_dir, "..", "cidc_api"))
 
 # Can only import cidc_api modules after the above paths are set
-from cidc_api.models import (
+from models import (
     Users,
     TrialMetadata,
     AssayUploads,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ test_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(test_dir, "..", "cidc_api"))
 
 # Can only import cidc_api modules after the above paths are set
-from models import (
+from cidc_api.models import (
     Users,
     TrialMetadata,
     AssayUploads,


### PR DESCRIPTION
Fixes a bug in #112 that prevents admins from uploading manifests/assays.