### PR TITLE
Add build matrix for parallel pypi and gae builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
     - PYTHONPATH=$PYTHONPATH:$(pwd)/cidc_api
     - GOOGLE_APPLICATION_CREDENTIALS=$HOME/credentials.json
     - CLOUDSDK_CORE_DISABLE_PROMPTS=1
+  matrix:
+    - DEPLOY=pypi
+    - DEPLOY=gae
 install:
   - pip install -r requirements.dev.txt
 before_script:
@@ -36,6 +39,7 @@ deploy:
     script: gcloud beta app deploy app.staging.yaml --project cidc-dfci-staging --no-cache -v "travis-$TRAVIS_BRANCH-${TRAVIS_COMMIT:0:7}-$TRAVIS_BUILD_NUMBER"
     on:
       branch: master
+      condition: $DEPLOY = gae
   - provider: script
     script: gcloud beta app deploy app.prod.yaml --project cidc-dfci --no-cache -v "travis-$TRAVIS_BRANCH-${TRAVIS_COMMIT:0:7}-$TRAVIS_BUILD_NUMBER"
     on:
@@ -47,3 +51,4 @@ deploy:
     skip_existing: true
     on:
       branch: master
+      condition: $DEPLOY = pypi


### PR DESCRIPTION
So `cidc-api-modules` updates won't need to wait for the GAE deploy