### PR TITLE
Add secure: always config to app.*.yaml

### DIFF
--- a/app.prod.yaml
+++ b/app.prod.yaml
@@ -5,6 +5,13 @@ entrypoint: gunicorn -b :$PORT --chdir cidc_api --log-level DEBUG app:app --time
 automatic_scaling:
   min_instances: 1
 
+handlers:
+# Force HTTPS on all requests
+- url: /.*
+  script: auto
+  secure: always
+  redirect_http_response_code: 301
+
 env_variables:
   ENV: 'prod'
   AUTH0_DOMAIN: 'cidc.auth0.com'

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -2,6 +2,13 @@ runtime: python37
 env: standard
 entrypoint: gunicorn -b :$PORT --chdir cidc_api --log-level DEBUG app:app --timeout 60
 
+handlers:
+# Force HTTPS on all requests
+- url: /.*
+  script: auto
+  secure: always
+  redirect_http_response_code: 301
+
 env_variables:
   ENV: 'staging'
   AUTH0_DOMAIN: 'cidc-test.auth0.com'


### PR DESCRIPTION
Already deployed these config updates to the staging API
```bash
$ curl -I http://staging-api.cimac-network.org
HTTP/1.1 301 Moved Permanently
Location: https://staging-api.cimac-network.org/
X-Cloud-Trace-Context: ff8a6e747d79f6366f68f224c821c1a9
Date: Thu, 10 Oct 2019 13:43:07 GMT
Server: Google Frontend
Content-Type: text/html
Via: 1.1 phswsa22.partners.org:80 (Cisco-WSA/11.5.2-020)
Connection: keep-alive
```