### PR TITLE
672 manifest full validation

### DIFF
--- a/cidc_api/gcloud_client.py
+++ b/cidc_api/gcloud_client.py
@@ -63,6 +63,8 @@ def upload_xlsx_to_gcs(
 
     upload_bucket: storage.Bucket = _get_bucket(GOOGLE_UPLOAD_BUCKET)
     blob = upload_bucket.blob(blob_name)
+
+    filebytes.seek(0)
     blob.upload_from_file(filebytes)
 
     data_bucket = _get_bucket(GOOGLE_DATA_BUCKET)

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -359,9 +359,11 @@ class TrialMetadata(CommonColumns):
         trial = TrialMetadata.select_for_update_by_trial_id(trial_id, session=session)
 
         # Merge assay metadata into the existing clinical trial metadata
-        updated_metadata = prism.merge_clinical_trial_metadata(
+        updated_metadata, errs = prism.merge_clinical_trial_metadata(
             json_patch, trial.metadata_json
         )
+        if errs:
+            raise Exception(errs)
         # Save updates to trial record
         trial.metadata_json = updated_metadata
         trial._etag = make_etag(trial.trial_id, updated_metadata)

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -279,6 +279,10 @@ class Permissions(CommonColumns):
         )
 
 
+class ValidationMultiError(Exception):
+    """Holds multiple jsonschema.ValidationErros"""
+    pass
+
 class TrialMetadata(CommonColumns):
     # TODO: split up metadata_json into separate `manifest`, `assays`, and `trial_info` fields on this table.
 
@@ -363,7 +367,7 @@ class TrialMetadata(CommonColumns):
             json_patch, trial.metadata_json
         )
         if errs:
-            raise Exception(errs)
+            raise ValidationMultiError(errs)
         # Save updates to trial record
         trial.metadata_json = updated_metadata
         trial._etag = make_etag(trial.trial_id, updated_metadata)

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -281,7 +281,9 @@ class Permissions(CommonColumns):
 
 class ValidationMultiError(Exception):
     """Holds multiple jsonschema.ValidationErros"""
+
     pass
+
 
 class TrialMetadata(CommonColumns):
     # TODO: split up metadata_json into separate `manifest`, `assays`, and `trial_info` fields on this table.

--- a/cidc_api/services/ingestion.py
+++ b/cidc_api/services/ingestion.py
@@ -7,12 +7,7 @@ import datetime
 from typing import BinaryIO, Tuple, List, NamedTuple
 from functools import wraps
 
-from werkzeug.exceptions import (
-    BadRequest,
-    InternalServerError,
-    NotFound,
-    Unauthorized,
-)
+from werkzeug.exceptions import BadRequest, InternalServerError, NotFound, Unauthorized
 
 from eve import Eve
 from sqlalchemy.orm.exc import NoResultFound
@@ -158,7 +153,6 @@ def upload_handler(f):
         print(f"upload_handler({f.__name__}) started")
         template_type, schema_path, xlsx_file = extract_schema_and_xlsx()
 
-
         # Run basic validations on the provided Excel file
         validations = validate(template_type, xlsx_file)
         if len(validations.json["errors"]) > 0:
@@ -181,30 +175,24 @@ def upload_handler(f):
                 f"Trial with {prism.PROTOCOL_ID_FIELD_NAME}={trial_id} not found."
             )
 
-
         # Try to merge assay metadata into the existing clinical trial metadata
         # Ignoring result as we inly want to check there's no validation errors
         try:
-            merged_md = prism.merge_clinical_trial_metadata(md_patch, trial.metadata_json)
+            merged_md = prism.merge_clinical_trial_metadata(
+                md_patch, trial.metadata_json
+            )
         except ValidationError as e:
             raise BadRequest(f"{e.message} in {e.instance}")
         except prism.InvalidMergeTargetException:
-            raise BadRequest(f"Internal error with {trial_id!r}. Please contact CIDC Administrator.")
-
+            raise BadRequest(
+                f"Internal error with {trial_id!r}. Please contact CIDC Administrator."
+            )
 
         return f(
-            user,
-            trial,
-            template_type,
-            xlsx_file,
-            md_patch,
-            file_infos,
-            *args,
-            **kwargs,
+            user, trial, template_type, xlsx_file, md_patch, file_infos, *args, **kwargs
         )
 
     return wrapped
-
 
 
 @ingestion_api.route("/validate", methods=["POST"])

--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -3,4 +3,4 @@ flask-sqlalchemy~=2.4.0
 eve-sqlalchemy~=0.7.0
 eve-swagger~=0.0.11
 google-cloud-storage~=1.18.0
-cidc-schemas~=0.7.1
+cidc-schemas~=0.8.0

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     packages=["cidc_api.config"],
     py_modules=["cidc_api.models"],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.6.6",
+    version="0.8.0",
     zip_safe=False,
 )

--- a/tests/services/test_ingestion.py
+++ b/tests/services/test_ingestion.py
@@ -158,7 +158,7 @@ def test_upload_manifest_non_existing_trial_id(
 
     res = client.post(MANIFEST_UPLOAD, data=form_data("pbmc.xlsx", some_file, "pbmc"))
     assert res.status_code == 400
-    assert "test-non-existing-trial-id" in res.json["_error"]["message"]
+    assert "test-non-existing-trial-id" in str(res.json["_error"]["message"])
 
     # Check that we tried to upload the excel file
     mocks.upload_xlsx.assert_not_called()
@@ -174,6 +174,8 @@ def test_upload_invalid_manifest(
     mocks = UploadMocks(monkeypatch)
 
     mocks.iter_errors.return_value = ["bad, bad error"]
+
+    give_upload_permission(test_user, TEST_TRIAL, "pbmc", db)
 
     client = app_no_auth.test_client()
 
@@ -259,7 +261,7 @@ def test_upload_manifest(
         MANIFEST_UPLOAD, data=form_data("pbmc.xlsx", io.BytesIO(b"a"), "pbmc")
     )
     assert res.status_code == 401
-    assert "not authorized to upload pbmc data" in res.json["_error"]["message"]
+    assert "not authorized to upload pbmc data" in str(res.json["_error"]["message"])
 
     # Add permission and retry the upload
     give_upload_permission(test_user, TEST_TRIAL, "pbmc", db)
@@ -399,7 +401,7 @@ def test_upload_wes(app_no_auth, test_user, db_with_trial_and_user, db, monkeypa
         ASSAY_UPLOAD, data=form_data("wes.xlsx", io.BytesIO(b"1234"), "wes")
     )
     assert res.status_code == 401
-    assert "not authorized to upload wes data" in res.json["_error"]["message"]
+    assert "not authorized to upload wes data" in str(res.json["_error"]["message"])
 
     mocks.clear_all()
 
@@ -489,7 +491,7 @@ def test_upload_olink(app_no_auth, test_user, db_with_trial_and_user, db, monkey
         ASSAY_UPLOAD, data=form_data("olink.xlsx", io.BytesIO(b"1234"), "olink")
     )
     assert res.status_code == 401
-    assert "not authorized to upload olink data" in res.json["_error"]["message"]
+    assert "not authorized to upload olink data" in str(res.json["_error"]["message"])
 
     mocks.clear_all()
 


### PR DESCRIPTION
Will address in future: 
* prismify/merge errors should have context in terms of Excel rows/cells.
* add saving "manifest draft" to the DB on validation, and then only apply it on submission.