### PR TITLE
Handle CLI version on authenticated endpoints

### DIFF
--- a/cidc_api/auth.py
+++ b/cidc_api/auth.py
@@ -6,7 +6,7 @@ import requests
 from eve.auth import TokenAuth
 from jose import jwt
 from flask import _request_ctx_stack, request, current_app as app
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Unauthorized, BadRequest
 
 from models import Users
 from config.settings import AUTH0_DOMAIN, ALGORITHMS, AUTH0_CLIENT_ID, TESTING

--- a/cidc_api/auth.py
+++ b/cidc_api/auth.py
@@ -1,4 +1,5 @@
 import logging
+from packaging import version
 from functools import wraps
 from typing import List
 
@@ -97,7 +98,7 @@ class BearerAuth(TokenAuth):
         if not user_agent:
             return
 
-        client, version = user_agent.split("/")
+        client, client_version = user_agent.split("/")
 
         # Old CLI versions don't update the User-Agent header, so we (perhaps dangerously)
         # assume any request coming from the python requests library is from a "very" old
@@ -106,7 +107,9 @@ class BearerAuth(TokenAuth):
 
         # Newer version of the CLI update the User-Agent header to `cidc-cli/{version}`,
         # so we can assess whether the requester needs to update their CLI.
-        is_old_cli = client == "cidc-cli" and version < app.config["MIN_CLI_VERSION"]
+        is_old_cli = client == "cidc-cli" and version.parse(
+            client_version
+        ) < version.parse(app.config["MIN_CLI_VERSION"])
 
         if is_very_old_cli or is_old_cli:
             print("cancelling request: detected outdated CLI")

--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -16,6 +16,7 @@ ENV = environ.get("ENV", "staging")
 assert ENV in ("dev", "staging", "prod")
 DEBUG = ENV == "dev" and environ.get("DEBUG")
 TESTING = environ.get("TESTING") == "True"
+MIN_CLI_VERSION = "0.5.3"
 ## End application environment config
 
 secrets = get_secret_manager(TESTING)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from jose import jwt
 from unittest.mock import MagicMock
 from flask import _request_ctx_stack
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Unauthorized, BadRequest
 
 from cidc_api.auth import BearerAuth
 from cidc_api.models import Users, CIDCRole
@@ -61,6 +61,37 @@ def test_check_auth_auth_error(monkeypatch, bearer_auth):
     # Authentication should fail and bubble this error up
     with pytest.raises(Unauthorized):
         bearer_auth.check_auth(TOKEN, [], RESOURCE, "GET")
+
+
+def test_enforce_cli_version(bearer_auth, app_no_auth):
+    target_version = "1.1.1"
+    app_no_auth.config["MIN_CLI_VERSION"] = target_version
+
+    def test_with_user_agent(client, version):
+        with app_no_auth.test_request_context(
+            "/", headers={"User-Agent": f"{client}/{version}"}
+        ):
+            bearer_auth.enforce_cli_version()
+
+    match = "upgrade to the most recent version"
+
+    # Reject python-requests requests
+    with pytest.raises(BadRequest, match=match):
+        test_with_user_agent("python-requests", "")
+
+    # Reject too-low cidc-cli clients
+    too_low = ["0.1.2", "0.1.0"]
+    for v in too_low:
+        with pytest.raises(BadRequest, match=match):
+            test_with_user_agent("cidc-cli", v)
+
+    # Accept high-enough CLI clients
+    high_enough = ["1.1.2", "1.11.1"]
+    for v in high_enough:
+        test_with_user_agent("cidc-cli", v)
+
+    # Accept non-CLI clients
+    test_with_user_agent("foobar", "")
 
 
 def test_token_auth(monkeypatch, bearer_auth):


### PR DESCRIPTION
This PR sets up the API to reject requests on authenticated endpoints from clients who appear to be using outdated versions of the CIDC-CLI.