### PR TITLE
Use PreconditionFailed and fix user agent strings bug

### DIFF
--- a/cidc_api/auth.py
+++ b/cidc_api/auth.py
@@ -7,7 +7,7 @@ import requests
 from eve.auth import TokenAuth
 from jose import jwt
 from flask import _request_ctx_stack, request, current_app as app
-from werkzeug.exceptions import Unauthorized, BadRequest
+from werkzeug.exceptions import Unauthorized, BadRequest, PreconditionFailed
 
 from models import Users
 from config.settings import AUTH0_DOMAIN, ALGORITHMS, AUTH0_CLIENT_ID, TESTING
@@ -98,7 +98,7 @@ class BearerAuth(TokenAuth):
         if not user_agent:
             return
 
-        client, client_version = user_agent.split("/")
+        client, client_version = user_agent.split("/", 1)
 
         # Old CLI versions don't update the User-Agent header, so we (perhaps dangerously)
         # assume any request coming from the python requests library is from a "very" old
@@ -113,11 +113,17 @@ class BearerAuth(TokenAuth):
 
         if is_very_old_cli or is_old_cli:
             print("cancelling request: detected outdated CLI")
-            raise BadRequest(
+            message = (
                 "You appear to be using an out-of-date version of the CIDC CLI. "
                 "Please upgrade to the most recent version:\n"
                 "    pip3 install --upgrade cidc-cli"
             )
+            if is_very_old_cli:
+                # This is semantically incorrect, but there is no other way
+                # to get the error message to show up for the oldest versions of the CLI
+                raise Unauthorized(message)
+            else:
+                raise PreconditionFailed(message)
 
     def role_auth(
         self, profile: dict, allowed_roles: List[str], resource: str, method: str

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from jose import jwt
 from unittest.mock import MagicMock
 from flask import _request_ctx_stack
-from werkzeug.exceptions import Unauthorized, BadRequest
+from werkzeug.exceptions import Unauthorized, BadRequest, PreconditionFailed
 
 from cidc_api.auth import BearerAuth
 from cidc_api.models import Users, CIDCRole
@@ -76,13 +76,13 @@ def test_enforce_cli_version(bearer_auth, app_no_auth):
     match = "upgrade to the most recent version"
 
     # Reject python-requests requests
-    with pytest.raises(BadRequest, match=match):
+    with pytest.raises(Unauthorized, match=match):
         test_with_user_agent("python-requests", "")
 
     # Reject too-low cidc-cli clients
     too_low = ["0.1.2", "0.1.0"]
     for v in too_low:
-        with pytest.raises(BadRequest, match=match):
+        with pytest.raises(PreconditionFailed, match=match):
             test_with_user_agent("cidc-cli", v)
 
     # Accept high-enough CLI clients
@@ -91,7 +91,7 @@ def test_enforce_cli_version(bearer_auth, app_no_auth):
         test_with_user_agent("cidc-cli", v)
 
     # Accept non-CLI clients
-    test_with_user_agent("foobar", "")
+    test_with_user_agent("Mozilla/2.0 Firefox", "")
 
 
 def test_token_auth(monkeypatch, bearer_auth):


### PR DESCRIPTION
This PR fixes an unsafe `.split('/')` operation introduced in #142 that is currently causing all requests from browsers to the API to fail.

Also, this updates HTTP responses based on how out-of-date the requesting CLI is.