### PR TITLE
Generate templates on startup

### DIFF
--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -11,6 +11,8 @@ from flask import jsonify
 from flask_migrate import Migrate, upgrade
 from flask_cors import CORS
 
+import cidc_schemas
+
 from models import BaseModel
 from auth import BearerAuth
 from services import register_services
@@ -60,6 +62,12 @@ db.Model = BaseModel
 Migrate(app, db, MIGRATIONS)
 with app.app_context():
     upgrade(MIGRATIONS)
+
+# Generate empty manifest/assay templates on startup
+print(
+    f"Writing empty templates to {app.config['TEMPLATES_DIR']} (cidc_schemas=={cidc_schemas.__version__})"
+)
+cidc_schemas.template.generate_all_templates(app.config["TEMPLATES_DIR"])
 
 # Configure the swagger site
 # TODO: flesh this out

--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -1,5 +1,5 @@
 import tempfile
-from os import environ
+from os import environ, path
 from copy import deepcopy
 
 from dotenv import load_dotenv
@@ -17,6 +17,7 @@ assert ENV in ("dev", "staging", "prod")
 DEBUG = ENV == "dev" and environ.get("DEBUG")
 TESTING = environ.get("TESTING") == "True"
 MIN_CLI_VERSION = "0.5.3"
+TEMPLATES_DIR = path.join("/tmp", "templates")
 ## End application environment config
 
 secrets = get_secret_manager(TESTING)

--- a/cidc_api/services/info.py
+++ b/cidc_api/services/info.py
@@ -1,6 +1,5 @@
 """Endpoints providing info related to this API"""
 import os
-import re
 
 from flask import Blueprint, jsonify, current_app as app, send_file
 from werkzeug.exceptions import NotFound, BadRequest
@@ -36,9 +35,6 @@ def extra_data_types():
     return jsonify(EXTRA_DATA_TYPES)
 
 
-alphabetic = re.compile(r"^[a-zA-Z]*$")
-
-
 @info_api.route("templates/<template_family>/<template_type>", methods=["GET"])
 def templates(template_family, template_type):
     """
@@ -47,9 +43,9 @@ def templates(template_family, template_type):
     `template_type` (e.g., pbmc, olink).
     """
     # Check that both strings are alphabetic
-    if not alphabetic.match(template_family):
+    if not template_family.isalpha():
         raise BadRequest(f"Invalid template family: {template_family}")
-    elif not alphabetic.match(template_type):
+    elif not template_type.isalpha():
         raise BadRequest(f"Invalid template type: {template_type}")
 
     path = os.path.join(

--- a/cidc_api/services/info.py
+++ b/cidc_api/services/info.py
@@ -1,5 +1,9 @@
 """Endpoints providing info related to this API"""
-from flask import Blueprint, jsonify
+import os
+import re
+
+from flask import Blueprint, jsonify, current_app as app, send_file
+from werkzeug.exceptions import NotFound, BadRequest
 
 from cidc_schemas import prism
 
@@ -30,3 +34,30 @@ def manifests():
 def extra_data_types():
     """List all extra data types on which permissions can be granted"""
     return jsonify(EXTRA_DATA_TYPES)
+
+
+alphabetic = re.compile(r"^[a-zA-Z]*$")
+
+
+@info_api.route("templates/<template_family>/<template_type>", methods=["GET"])
+def templates(template_family, template_type):
+    """
+    Return the empty Excel template file for the given 
+    `template_family` (e.g., manifests, metadata) and 
+    `template_type` (e.g., pbmc, olink).
+    """
+    # Check that both strings are alphabetic
+    if not alphabetic.match(template_family):
+        raise BadRequest(f"Invalid template family: {template_family}")
+    elif not alphabetic.match(template_type):
+        raise BadRequest(f"Invalid template type: {template_type}")
+
+    path = os.path.join(
+        app.config["TEMPLATES_DIR"], template_family, f"{template_type}_template.xlsx"
+    )
+
+    # Check that the template exists
+    if not os.path.exists(path):
+        raise NotFound(f"No {template_family} template exists for {template_type}")
+
+    return send_file(path)

--- a/cidc_api/services/info.py
+++ b/cidc_api/services/info.py
@@ -58,6 +58,8 @@ def templates(template_family, template_type):
 
     # Check that the template exists
     if not os.path.exists(path):
-        raise NotFound(f"No {template_family} template exists for {template_type}")
+        raise NotFound(
+            f"No template found for the given template family and template type"
+        )
 
     return send_file(path)

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from werkzeug.exceptions import BadRequest, NotFound
 
@@ -46,9 +48,21 @@ def test_templates(app_no_auth):
     assert res.status_code == 404
 
     # Existing manifest
+    pbmc_path = os.path.join(
+        app_no_auth.config["TEMPLATES_DIR"], "manifests", "pbmc_template.xlsx"
+    )
+    with open(pbmc_path, "rb") as f:
+        real_pbmc_file = f.read()
     res = client.get(f"{INFO_ENDPOINT}/templates/manifests/pbmc")
     assert res.status_code == 200
+    assert res.data == real_pbmc_file
 
     # Existing assay
+    olink_path = os.path.join(
+        app_no_auth.config["TEMPLATES_DIR"], "metadata", "olink_template.xlsx"
+    )
+    with open(olink_path, "rb") as f:
+        real_olink_file = f.read()
     res = client.get(f"{INFO_ENDPOINT}/templates/metadata/olink")
     assert res.status_code == 200
+    assert res.data == real_olink_file

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -1,3 +1,6 @@
+import pytest
+from werkzeug.exceptions import BadRequest, NotFound
+
 INFO_ENDPOINT = "/info"
 
 
@@ -23,3 +26,29 @@ def test_info_extra_types(app_no_auth):
     res = client.get(f"{INFO_ENDPOINT}/extra_data_types")
     assert type(res.json) == list
     assert "participants info" in res.json
+
+
+def test_templates(app_no_auth):
+    """Check that the /info/templates endpoint behaves as expected"""
+    client = app_no_auth.test_client()
+
+    # Invalid URLs
+    res = client.get(f"{INFO_ENDPOINT}/templates/../pbmc")
+    assert res.status_code == 400
+    assert res.json["_error"]["message"] == "Invalid template family: .."
+
+    res = client.get(f"{INFO_ENDPOINT}/templates/manifests/pbmc123")
+    assert res.status_code == 400
+    assert res.json["_error"]["message"] == "Invalid template type: pbmc123"
+
+    # Non-existent template
+    res = client.get(f"{INFO_ENDPOINT}/templates/foo/bar")
+    assert res.status_code == 404
+
+    # Existing manifest
+    res = client.get(f"{INFO_ENDPOINT}/templates/manifests/pbmc")
+    assert res.status_code == 200
+
+    # Existing assay
+    res = client.get(f"{INFO_ENDPOINT}/templates/metadata/olink")
+    assert res.status_code == 200


### PR DESCRIPTION
Now, the API generates empty schemas templates on application startup and serves them from the `/info/templates/...` endpoint.

Accompanying UI changes to come. 