### PR TITLE
Send email alerting successful assay/manifest upload

### DIFF
--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 
 from . import db
 from . import get_secret_manager
-from models import get_DOMAIN
+from cidc_api.models import get_DOMAIN
 
 load_dotenv()
 

--- a/cidc_api/emails.py
+++ b/cidc_api/emails.py
@@ -57,7 +57,7 @@ def new_upload_alert(upload: Union[AssayUploads, ManifestUploads]) -> dict:
         upload.assay_type if hasattr(upload, "assay_type") else upload.manifest_type
     )
 
-    subject = f"[UPLOAD SUCCESS] {upload_type} uploaded to {upload.trial_id}"
+    subject = f"[UPLOAD SUCCESS]({ENV}) {upload_type} uploaded to {upload.trial_id}"
 
     html_content = f"""
     <ul>

--- a/cidc_api/emails.py
+++ b/cidc_api/emails.py
@@ -2,9 +2,9 @@
 from functools import wraps
 from typing import Union
 
-import gcloud_client
-from models import Users, AssayUploads, ManifestUploads
-from config.settings import ENV
+from cidc_api import gcloud_client
+from cidc_api.models import Users, AssayUploads, ManifestUploads
+from cidc_api.config.settings import ENV
 
 CIDC_MAILING_LIST = "cidc@jimmy.harvard.edu"
 

--- a/cidc_api/emails.py
+++ b/cidc_api/emails.py
@@ -1,6 +1,7 @@
 """Template functions for CIDC email bodies."""
+from typing import Union
 
-from models import Users
+from models import Users, AssayUploads, ManifestUploads
 from config.settings import ENV
 
 CIDC_MAILING_LIST = "cidc@jimmy.harvard.edu"
@@ -39,6 +40,33 @@ def new_user_registration(email: str) -> dict:
         f"A new user, {email}, has registered for the CIMAC-CIDC Data Portal ({ENV}). If you are a CIDC Admin, "
         "please visit the accounts management tab in the Portal to review their request."
     )
+
+    email = {
+        "to_emails": [CIDC_MAILING_LIST],
+        "subject": subject,
+        "html_content": html_content,
+    }
+
+    return email
+
+
+def new_upload_alert(upload: Union[AssayUploads, ManifestUploads]) -> dict:
+    """Alert the CIDC administrators that an upload succeeded."""
+
+    upload_type = (
+        upload.assay_type if hasattr(upload, "assay_type") else upload.manifest_type
+    )
+
+    subject = f"[UPLOAD SUCCESS] {upload_type} uploaded to {upload.trial_id}"
+
+    html_content = f"""
+    <ul>
+        <li><strong>upload job id:</strong> {upload.id}</li>
+        <li><strong>trial id:</strong> {upload.trial_id}</li>
+        <li><strong>type:</strong> {upload_type}</li>
+        <li><strong>uploader:</strong> {upload.uploader_email}</li>
+    </ul
+    """
 
     email = {
         "to_emails": [CIDC_MAILING_LIST],

--- a/cidc_api/gcloud_client.py
+++ b/cidc_api/gcloud_client.py
@@ -12,7 +12,7 @@ from requests.exceptions import Timeout
 from google.cloud import storage
 from google.cloud import pubsub
 
-from config.settings import (
+from cidc_api.config.settings import (
     GOOGLE_UPLOAD_ROLE,
     GOOGLE_UPLOAD_BUCKET,
     GOOGLE_UPLOAD_TOPIC,

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -639,7 +639,7 @@ class AssayUploads(CommonColumns, UploadForeignKeys):
         return upload
 
     @with_default_session
-    def ingestion_success(self, session):
+    def ingestion_success(self, session, commit=False):
         """Set own status to reflect successful merge and trigger email notifying CIDC admins."""
         # Do status update if the transition is valid
         if not AssayUploadStatus.is_valid_transition(
@@ -649,7 +649,9 @@ class AssayUploads(CommonColumns, UploadForeignKeys):
                 f"Cannot declare ingestion success given current status: {self.status}"
             )
         self.status = AssayUploadStatus.MERGE_COMPLETED.value
-        session.commit()
+
+        if commit:
+            session.commit()
 
         self.alert_upload_success()
 

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -482,6 +482,7 @@ class ManifestUploads(CommonColumns, UploadForeignKeys):
         gcs_xlsx_uri: str,
         session: Session,
         commit: bool = True,
+        send_email: bool = False,
     ):
         """Create a new ManifestUpload for the given trial manifest patch."""
         assert (
@@ -500,6 +501,9 @@ class ManifestUploads(CommonColumns, UploadForeignKeys):
         session.add(upload)
         if commit:
             session.commit()
+
+        if send_email:
+            upload.alert_upload_success()
 
         return upload
 
@@ -639,7 +643,9 @@ class AssayUploads(CommonColumns, UploadForeignKeys):
         return upload
 
     @with_default_session
-    def ingestion_success(self, session: Session, commit: bool = False):
+    def ingestion_success(
+        self, session: Session, commit: bool = False, send_email: bool = False
+    ):
         """Set own status to reflect successful merge and trigger email notifying CIDC admins."""
         # Do status update if the transition is valid
         if not AssayUploadStatus.is_valid_transition(
@@ -653,7 +659,8 @@ class AssayUploads(CommonColumns, UploadForeignKeys):
         if commit:
             session.commit()
 
-        self.alert_upload_success()
+        if send_email:
+            self.alert_upload_success()
 
 
 class DownloadableFiles(CommonColumns):

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -639,7 +639,7 @@ class AssayUploads(CommonColumns, UploadForeignKeys):
         return upload
 
     @with_default_session
-    def ingestion_success(self, session, commit=False):
+    def ingestion_success(self, session: Session, commit: bool = False):
         """Set own status to reflect successful merge and trigger email notifying CIDC admins."""
         # Do status update if the transition is valid
         if not AssayUploadStatus.is_valid_transition(

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -458,10 +458,10 @@ class UploadForeignKeys:
     def alert_upload_success(self):
         """Send an email notification that an upload has succeeded."""
         # (import these here to avoid a circular import error)
-        import emails, gcloud_client
+        import emails
 
         # Send admin notification email
-        gcloud_client.send_email(**emails.new_upload_alert(self))
+        emails.new_upload_alert(self, send_email=True)
 
 
 class ManifestUploads(CommonColumns, UploadForeignKeys):

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -582,9 +582,13 @@ class AssayUploads(CommonColumns, UploadForeignKeys):
             assay_patch=metadata,
             uploader_email=uploader_email,
             gcs_xlsx_uri=gcs_xlsx_uri,
-            status="started",
+            status=AssayUploadStatus.STARTED.value,
             _etag=make_etag(
-                assay_type, gcs_file_map, metadata, uploader_email, "started"
+                assay_type,
+                gcs_file_map,
+                metadata,
+                uploader_email,
+                AssayUploadStatus.STARTED.value,
             ),
         )
         session.add(job)
@@ -623,6 +627,12 @@ class AssayUploads(CommonColumns, UploadForeignKeys):
         if upload and upload.uploader_email != email:
             return None
         return upload
+
+    @with_default_session
+    def ingestion_success(self, session):
+        """Set own status to reflect successful merge and trigger email notifying CIDC admins."""
+        self.status = AssayUploadStatus.MERGE_COMPLETED.value
+        session.commit()
 
 
 class DownloadableFiles(CommonColumns):

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -458,7 +458,7 @@ class UploadForeignKeys:
     def alert_upload_success(self):
         """Send an email notification that an upload has succeeded."""
         # (import these here to avoid a circular import error)
-        import emails
+        from cidc_api import emails
 
         # Send admin notification email
         emails.new_upload_alert(self, send_email=True)

--- a/cidc_api/services/ingestion.py
+++ b/cidc_api/services/ingestion.py
@@ -287,6 +287,9 @@ def upload_manifest(
         session=session,
     )
 
+    # Manifest has been uploaded successfully
+    manifest_upload.alert_upload_success()
+
     # Publish that this trial's metadata has been updated
     gcloud_client.publish_patient_sample_update(trial.trial_id)
 

--- a/cidc_api/services/ingestion.py
+++ b/cidc_api/services/ingestion.py
@@ -285,10 +285,8 @@ def upload_manifest(
         metadata=md_patch,
         gcs_xlsx_uri=gcs_blob.name,
         session=session,
+        send_email=True,
     )
-
-    # Manifest has been uploaded successfully
-    manifest_upload.alert_upload_success()
 
     # Publish that this trial's metadata has been updated
     gcloud_client.publish_patient_sample_update(trial.trial_id)

--- a/cidc_api/services/users.py
+++ b/cidc_api/services/users.py
@@ -67,9 +67,8 @@ def alert_new_user_registered(items: list):
     assert len(items) == 1
 
     new_user = items[0]
-    email = new_user_registration(new_user["email"])
-
-    gcloud_client.send_email(**email)
+    # Send new user registration email
+    new_user_registration(new_user["email"], send_email=True)
 
 
 def add_approval_date(request: Request, lookup: dict):
@@ -93,5 +92,4 @@ def alert_new_user_approved(updates: dict, original: dict):
         # The user was just approved, so ping them.
         if updates["approval_date"] and not original.get("approval_date"):
             user = Users(**original)
-            email = confirm_account_approval(user)
-            gcloud_client.send_email(**email)
+            confirm_account_approval(user, send_email=True)

--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -3,4 +3,5 @@ flask-sqlalchemy~=2.4.0
 eve-sqlalchemy~=0.7.0
 eve-swagger~=0.0.11
 google-cloud-storage~=1.18.0
+google-cloud-pubsub==0.42.1
 cidc-schemas~=0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ flask-migrate==2.5.2
 python-dotenv==0.10.3
 requests==2.22.0
 six==1.12.0
-google-cloud-pubsub==0.42.1
 python-jose==3.0.1
 psycopg2-binary==2.8.3
 werkzeug~=0.15.4

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     packages=["cidc_api.config"],
     py_modules=["cidc_api.models", "cidc_api.gcloud_client", "cidc_api.emails"],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.9.3",
+    version="0.9.4",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=requirements,
     license="MIT license",
     packages=["cidc_api.config"],
-    py_modules=["cidc_api.models"],
+    py_modules=["cidc_api.models", "cidc_api.gcloud_client", "cidc_api.emails"],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
     version="0.9.3",
     zip_safe=False,

--- a/tests/services/test_ingestion.py
+++ b/tests/services/test_ingestion.py
@@ -248,7 +248,7 @@ def test_admin_upload(app, test_user, db_with_trial_and_user, monkeypatch):
 
 
 def test_upload_manifest(
-    app_no_auth, test_user, db_with_trial_and_user, db, monkeypatch
+    app_no_auth, test_user, db_with_trial_and_user, db, monkeypatch, capsys
 ):
     """Ensure the upload_manifest endpoint follows the expected execution flow"""
 
@@ -272,6 +272,9 @@ def test_upload_manifest(
         MANIFEST_UPLOAD, data=form_data("pbmc.xlsx", io.BytesIO(b"a"), "pbmc")
     )
     assert res.status_code == 200
+
+    # Check that upload alert email was "sent"
+    assert "Would send email with subject '[UPLOAD SUCCESS]" in capsys.readouterr()[0]
 
     # Check that we tried to publish a patient/sample update
     mocks.publish_patient_sample_update.assert_called_once()

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -1,7 +1,8 @@
-from cidc_api.models import Users
+from cidc_api.models import Users, AssayUploads, ManifestUploads
 from cidc_api.emails import (
     confirm_account_approval,
     new_user_registration,
+    new_upload_alert,
     CIDC_MAILING_LIST,
 )
 
@@ -22,3 +23,17 @@ def test_confirm_account_approval():
     assert email["to_emails"] == [user.email]
     assert "Approval" in email["subject"]
     assert "has now been approved" in email["html_content"]
+
+
+def test_new_upload_alert():
+    vals = {"id": 1, "trial_id": "foo", "uploader_email": "test@email.com"}
+
+    for upload in [
+        AssayUploads(**vals, assay_type="cytof"),
+        ManifestUploads(**vals, manifest_type="pbmc"),
+    ]:
+        email = new_upload_alert(upload)
+        assert "UPLOAD SUCCESS" in email["subject"]
+        assert email["to_emails"] == [CIDC_MAILING_LIST]
+        for val in vals.values():
+            assert str(val) in email["html_content"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import io
+import sys
 from functools import wraps
 from datetime import datetime
 from unittest.mock import MagicMock
@@ -224,6 +225,36 @@ def test_assay_upload_merge_extra_metadata(db, monkeypatch):
 
 
 @db_test
+def test_assay_upload_ingestion_success(db, monkeypatch, capsys):
+    """Check that the ingestion success method works as expected"""
+    new_user = Users.create(PROFILE)
+    TrialMetadata.create(TRIAL_ID, METADATA)
+    assay_upload = AssayUploads.create(
+        assay_type="cytof",
+        uploader_email=EMAIL,
+        gcs_file_map={},
+        metadata={PROTOCOL_ID_FIELD_NAME: TRIAL_ID},
+        gcs_xlsx_uri="",
+        commit=False,
+    )
+
+    db.commit()
+
+    # Ensure that success can't be declared from a starting state
+    with pytest.raises(Exception):
+        assay_upload.ingestion_success()
+
+    # Update assay_upload status to simulate a completed but not ingested upload
+    assay_upload.status = AssayUploadStatus.UPLOAD_COMPLETED.value
+    assay_upload.ingestion_success()
+
+    # Check that status was updated and email was sent
+    db_record = AssayUploads.find_by_id(assay_upload.id)
+    assert db_record.status == AssayUploadStatus.MERGE_COMPLETED.value
+    assert "Would send email with subject '[UPLOAD SUCCESS]" in capsys.readouterr()[0]
+
+
+@db_test
 def test_create_downloadable_file_from_metadata(db, monkeypatch):
     """Try to create a downloadable file from artifact_core metadata"""
     # fake file metadata
@@ -318,11 +349,12 @@ def test_assay_upload_status():
         AssayUploadStatus.MERGE_FAILED.value,
     ]
     for upload in upload_statuses:
+        assert AssayUploadStatus.is_valid_transition(AssayUploadStatus.STARTED, upload)
         for merge in merge_statuses:
+            assert not AssayUploadStatus.is_valid_transition(
+                AssayUploadStatus.STARTED, merge
+            )
             for status in [upload, merge]:
-                assert AssayUploadStatus.is_valid_transition(
-                    AssayUploadStatus.STARTED, status
-                )
                 assert not AssayUploadStatus.is_valid_transition(
                     status, AssayUploadStatus.STARTED
                 )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -248,9 +248,15 @@ def test_assay_upload_ingestion_success(db, monkeypatch, capsys):
     assay_upload.status = AssayUploadStatus.UPLOAD_COMPLETED.value
     assay_upload.ingestion_success()
 
-    # Check that status was updated and email was sent
+    # Check that status was updated and email wasn't sent by default
     db_record = AssayUploads.find_by_id(assay_upload.id)
     assert db_record.status == AssayUploadStatus.MERGE_COMPLETED.value
+    assert (
+        "Would send email with subject '[UPLOAD SUCCESS]" not in capsys.readouterr()[0]
+    )
+
+    # Check that email gets sent when specified
+    assay_upload.ingestion_success(send_email=True)
     assert "Would send email with subject '[UPLOAD SUCCESS]" in capsys.readouterr()[0]
 
 


### PR DESCRIPTION
This PR adds:
* the email template `new_upload_alert` to `emails.py`
* functionality for alerting upload success to the `AssayUploads` and `ManifestUploads` models
* a fix for a bug in `AssayUploadStatus`, where an assay upload in the `started` state could skip ahead to `merge-completed` before passing through `upload-completed`.

Next, trigger email alerts from the `ingest_upload` cloud function on success.