### PR TITLE
Move python-dotenv dependency to requirements.modules.txt

### DIFF
--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -5,3 +5,5 @@ eve-swagger~=0.0.11
 google-cloud-storage~=1.18.0
 google-cloud-pubsub==0.42.1
 cidc-schemas~=0.9.3
+python-dotenv==0.10.3
+

--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -6,4 +6,4 @@ google-cloud-storage~=1.18.0
 google-cloud-pubsub==0.42.1
 cidc-schemas~=0.9.3
 python-dotenv==0.10.3
-
+requests==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 flask-cors==3.0.8
 flask-migrate==2.5.2
-python-dotenv==0.10.3
 requests==2.22.0
 six==1.12.0
 python-jose==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 flask-cors==3.0.8
 flask-migrate==2.5.2
-requests==2.22.0
 six==1.12.0
 python-jose==3.0.1
 psycopg2-binary==2.8.3

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     packages=["cidc_api.config"],
     py_modules=["cidc_api.models", "cidc_api.gcloud_client", "cidc_api.emails"],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.9.4",
+    version="0.9.5",
     zip_safe=False,
 )


### PR DESCRIPTION
This missing dependency is currently causing the `ingest_uploads` cloud function to crash on staging.