### PR TITLE
Convert data_format and assay_type columns to CITEXT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_script:
   - psql -c "create user cidcdev with password '1234'"
   - psql -c "create database cidctest"
   - psql -c "grant all privileges on database cidctest to cidcdev"
+  - psql cidctest -c "create extension citext"
 script:
   - pytest
   - black --check cidc_api tests --target-version=py36

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ psql -c "create user cidcdev with password '1234'"
 # Database to use for local development
 psql -c "create database cidc"
 psql -c "grant all privileges on database cidc to cidcdev"
+psql cidc -c "create extension citext"
 
 # Database to use for automated testing
 psql -c "create database cidctest"
 psql -c "grant all privileges on database cidctest to cidcdev"
+psql cidctest -c "create extension citext"
 ```
 Now, you should be able to connect to your development database with the URI `postgresql://cidcdev:1234@localhost:5432/cidc`. Or, in the postgres REPL:
 ```bash

--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -680,9 +680,11 @@ class DownloadableFiles(CommonColumns):
     file_name = Column(String, nullable=False)
     file_size_bytes = Column(BigInteger, nullable=False)
     uploaded_timestamp = Column(DateTime, nullable=False)
+    # NOTE: this column actually has type CITEXT.
     data_format = Column(String, nullable=False)
     additional_metadata = Column(JSONB, nullable=True)
     # TODO rename assay_type, because we store manifests in there too.
+    # NOTE: this column actually has type CITEXT.
     assay_type = Column(String, nullable=False)
     md5_hash = Column(String, nullable=True)
     crc32c_hash = Column(String, nullable=True)

--- a/migrations/versions/f324cdb1a846_.py
+++ b/migrations/versions/f324cdb1a846_.py
@@ -1,0 +1,27 @@
+"""Update downloadable_files data_format and assay_type columns to CITEXT.
+
+Revision ID: f324cdb1a846
+Revises: 0c924d67603c
+Create Date: 2019-12-20 10:02:11.055006
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f324cdb1a846"
+down_revision = "0c924d67603c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # NOTE: this requires that a super user has already run `CREATE EXTENSION citext` on the db
+    op.execute("ALTER TABLE downloadable_files ALTER COLUMN data_format TYPE CITEXT")
+    op.execute("ALTER TABLE downloadable_files ALTER COLUMN assay_type TYPE CITEXT")
+
+
+def downgrade():
+    op.execute("ALTER TABLE downloadable_files ALTER COLUMN data_format TYPE VARCHAR")
+    op.execute("ALTER TABLE downloadable_files ALTER COLUMN assay_type TYPE VARCHAR")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -299,6 +299,14 @@ def test_create_downloadable_file_from_metadata(db, monkeypatch):
         assert getattr(new_file, k) == file_metadata[k]
     assert new_file.additional_metadata == additional_metadata
 
+    # Throw in an additional capitalization test
+    assert (
+        new_file
+        == db.query(DownloadableFiles)
+        .filter_by(data_format="fAsTq", assay_type="WeS")
+        .one()
+    )
+
 
 @db_test
 def test_create_downloadable_file_from_blob(db, monkeypatch):


### PR DESCRIPTION
I ran into issues implementing server-side faceted search because these values have all sorts of different capitalization schemes in the database. Changing the column types to `CITEXT` will allow for case-independent string comparisons.