### PR TITLE
Give CIDC-BIOFX-USER access to assay_uploads resource

### DIFF
--- a/cidc_api/models.py
+++ b/cidc_api/models.py
@@ -121,12 +121,16 @@ def get_DOMAIN() -> dict:
 
     # Restrict operations on the 'assay_uploads' resource:
     # * only admins can list 'assay_uploads' (TODO: we may want people to be able to view their own uploads)
-    # * only admins and cimac users can GET items or PATCH 'assay_uploads'
-    admin_and_cimac = [CIDCRole.ADMIN.value, CIDCRole.CIMAC_BIOFX_USER.value]
+    # * only admins, cimac biofx users, and cidc biofx users can GET items or PATCH 'assay_uploads'
+    admin_cimac_cidc = [
+        CIDCRole.ADMIN.value,
+        CIDCRole.CIMAC_BIOFX_USER.value,
+        CIDCRole.CIDC_BIOFX_USER.value,
+    ]
     domain["assay_uploads"]["allowed_read_roles"] = [CIDCRole.ADMIN.value]
-    domain["assay_uploads"]["allowed_item_read_roles"] = admin_and_cimac
-    domain["assay_uploads"]["allowed_write_roles"] = admin_and_cimac
-    domain["assay_uploads"]["allowed_item_write_roles"] = admin_and_cimac
+    domain["assay_uploads"]["allowed_item_read_roles"] = admin_cimac_cidc
+    domain["assay_uploads"]["allowed_write_roles"] = admin_cimac_cidc
+    domain["assay_uploads"]["allowed_item_write_roles"] = admin_cimac_cidc
     domain["assay_uploads"]["resource_methods"] = ["GET"]
     domain["assay_uploads"]["item_methods"] = ["GET", "PATCH"]
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -399,9 +399,9 @@ def test_rbac(monkeypatch, app, db):
                     assert res.status_code == 401
 
         # Test assay_uploads and manifest_uploads permissions
-        for resource, privileged_nonadmin in [
-            ("assay_uploads", CIDCRole.CIMAC_BIOFX_USER),
-            ("manifest_uploads", CIDCRole.NCI_BIOBANK_USER),
+        for resource, privileged_nonadmins in [
+            ("assay_uploads", [CIDCRole.CIMAC_BIOFX_USER, CIDCRole.CIDC_BIOFX_USER]),
+            ("manifest_uploads", [CIDCRole.NCI_BIOBANK_USER]),
         ]:
             # No one is allowed to PUT or POST to these endpoints
             res_post = client.post(resource, headers=HEADER, json={})
@@ -413,7 +413,7 @@ def test_rbac(monkeypatch, app, db):
             item = resource + "/1"
             res_patch = client.patch(item, headers=HEADER, json={})
             res_get_item = client.get(item, headers=HEADER)
-            if role in [CIDCRole.ADMIN, privileged_nonadmin]:
+            if role in [CIDCRole.ADMIN, *privileged_nonadmins]:
                 assert res_patch.status_code == 404
                 assert res_get_item.status_code == 404
             else:


### PR DESCRIPTION
...because analysis uploads are currently stored in the `assay_uploads` table, and users with the CIDC BIOFX role need to be able to access analysis uploads.