### PR TITLE
Bump schemas version and publish manifest ID, not trial ID, on manifest upload

### DIFF
--- a/cidc_api/gcloud_client.py
+++ b/cidc_api/gcloud_client.py
@@ -195,9 +195,9 @@ def publish_upload_success(job_id: int):
         report.result()
 
 
-def publish_patient_sample_update(trial_id: int):
-    """Publish to the patient_sample_update topic that patient/sample info for the given trial has been updated."""
-    report = _encode_and_publish(str(trial_id), GOOGLE_PATIENT_SAMPLE_TOPIC)
+def publish_patient_sample_update(manifest_upload_id: int):
+    """Publish to the patient_sample_update topic that a new manifest has been uploaded."""
+    report = _encode_and_publish(str(manifest_upload_id), GOOGLE_PATIENT_SAMPLE_TOPIC)
 
     # Wait for response from pub/sub
     if report:

--- a/cidc_api/services/ingestion.py
+++ b/cidc_api/services/ingestion.py
@@ -308,8 +308,8 @@ def upload_manifest(
         send_email=True,
     )
 
-    # Publish that this trial's metadata has been updated
-    gcloud_client.publish_patient_sample_update(trial.trial_id)
+    # Publish that a manifest upload has been received
+    gcloud_client.publish_patient_sample_update(manifest_upload.trial_id)
 
     return jsonify({"metadata_json_patch": md_patch})
 

--- a/cidc_api/services/ingestion.py
+++ b/cidc_api/services/ingestion.py
@@ -309,7 +309,7 @@ def upload_manifest(
     )
 
     # Publish that a manifest upload has been received
-    gcloud_client.publish_patient_sample_update(manifest_upload.trial_id)
+    gcloud_client.publish_patient_sample_update(manifest_upload.id)
 
     return jsonify({"metadata_json_patch": md_patch})
 

--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -4,6 +4,6 @@ eve-sqlalchemy~=0.7.0
 eve-swagger~=0.0.11
 google-cloud-storage~=1.18.0
 google-cloud-pubsub==0.42.1
-cidc-schemas~=0.13.4
+cidc-schemas~=0.14.1
 python-dotenv==0.10.3
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     packages=["cidc_api.config"],
     py_modules=["cidc_api.models", "cidc_api.gcloud_client", "cidc_api.emails"],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.13.4",
+    version="0.14.1",
     zip_safe=False,
 )


### PR DESCRIPTION
Publishing the manifest upload ID to the `patient_sample_update` topic is required to use `unprism.derive_files` in the `generate_csvs` cloud function.