### PR TITLE
Resolve deprecation warning and don't use '.add' method

### DIFF
--- a/cidc_api/gcloud_client.py
+++ b/cidc_api/gcloud_client.py
@@ -98,7 +98,8 @@ def grant_upload_access(user_email: str):
 
     # Update the bucket IAM policy to include the user as an uploader.
     policy = bucket.get_iam_policy()
-    policy[GOOGLE_UPLOAD_ROLE].add(policy.user(user_email))
+    policy[GOOGLE_UPLOAD_ROLE] = {*policy[GOOGLE_UPLOAD_ROLE], f"user:{user_email}"}
+    print(f"{GOOGLE_UPLOAD_ROLE} binding updated to {policy[GOOGLE_UPLOAD_ROLE]}")
     bucket.set_iam_policy(policy)
 
 
@@ -111,7 +112,7 @@ def revoke_upload_access(user_email: str):
 
     # Update the bucket IAM policy to remove the user's uploader privileges.
     policy = bucket.get_iam_policy()
-    policy[GOOGLE_UPLOAD_ROLE].discard(policy.user(user_email))
+    policy[GOOGLE_UPLOAD_ROLE].discard(f"user:{user_email}")
     bucket.set_iam_policy(policy)
 
 

--- a/cidc_api/gcloud_client.py
+++ b/cidc_api/gcloud_client.py
@@ -113,6 +113,7 @@ def revoke_upload_access(user_email: str):
     # Update the bucket IAM policy to remove the user's uploader privileges.
     policy = bucket.get_iam_policy()
     policy[GOOGLE_UPLOAD_ROLE].discard(f"user:{user_email}")
+    print(f"{GOOGLE_UPLOAD_ROLE} binding updated to {policy[GOOGLE_UPLOAD_ROLE]}")
     bucket.set_iam_policy(policy)
 
 

--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -2,7 +2,7 @@ flask~=1.1.1
 flask-sqlalchemy~=2.4.0
 eve-sqlalchemy~=0.7.0
 eve-swagger~=0.0.11
-google-cloud-storage~=1.18.0
+google-cloud-storage~=1.25.0
 google-cloud-pubsub==0.42.1
 cidc-schemas~=0.15.4
 python-dotenv==0.10.3


### PR DESCRIPTION
For a reason I don't yet understand
```python
policy[GOOGLE_UPLOAD_ROLE].add(policy.user(user_email))
``` 
does not successfully update the IAM policy on `GOOGLE_UPLOAD_BUCKET` when running in App Engine (the code works fine locally).

The changes in this PR ensure that the bucket IAM policy is updated appropriately.