### PR TITLE
Pin werkzeug and pymongo versions to avoid breaking eve-sqlalchemy

### DIFF
--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -1,5 +1,7 @@
 flask~=1.1.1
 flask-sqlalchemy~=2.4.0
+werkzeug~=0.15.4 # required to fix an Eve-SQLAlchemy dependency issue
+pymongo==3.5.0 # required to fix an Eve-SQLAlchemy dependency issue
 eve-sqlalchemy~=0.7.0
 eve-swagger~=0.0.11
 google-cloud-storage~=1.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ flask-migrate==2.5.2
 six==1.12.0
 python-jose==3.0.1
 psycopg2-binary==2.8.3
-werkzeug~=0.15.4
 packaging==19.2
 gunicorn
 -r requirements.modules.txt

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     packages=["cidc_api.config"],
     py_modules=["cidc_api.models", "cidc_api.gcloud_client", "cidc_api.emails"],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.16.4",
+    version="0.16.5",
     zip_safe=False,
 )


### PR DESCRIPTION
Last week, we noticed that, suddenly, `werkzeug`-related `ImportError`s started appearing when running this and the CFn repo's Travis build, even though we'd made no changes that use `werkzeug`, `flask`, or `eve` directly. 

After some investigation, I learned that the issue causing this error traces back to `eve-sqlalchemy` using a very out-of-date version of `eve`. The version of `eve` that `eve-sqlalchemy` depends on requires `werkzeug==0.11.15` (though local testing suggests it works fine for any `werkzeug<1.0`). The CIDC API depends on `flask~=1.1.1`, and `flask>=1.0` depends on `werkzeug>=0.15` (see https://github.com/pallets/flask/blob/909b9751eec79871164bd909b772934bc3419969/setup.py#L56). `werkzeug` just released its version 1.0.0 last week, so the breaking changes in `werkzeug>=1` are pulled into a fresh install of `cidc-api-modules` in Travis (or locally, if you use a fresh virtualenv), leading to the `ImportError` thrown by outdated `eve`.

Pinning the `werkzeug` version surfaced a new error related to the `pymongo` dependency `bson`, so `pymongo`'s version is also pinned (we don't use any of `eve`'s mongodb functionality, so this won't impact us).