### PR TITLE
settings.config.ENV shouldn't default to 'staging'

### DIFF
--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -12,8 +12,12 @@ load_dotenv()
 
 
 ## Configure application environment
-ENV = environ.get("ENV", "staging")
-assert ENV in ("dev", "staging", "prod")
+ENV = environ.get("ENV")
+assert ENV in (
+    "dev",
+    "staging",
+    "prod",
+), "ENV environment variable must be set to 'dev', 'staging', or 'prod'"
 DEBUG = ENV == "dev" and environ.get("DEBUG")
 TESTING = environ.get("TESTING") == "True"
 MIN_CLI_VERSION = "0.8.0"


### PR DESCRIPTION
companion to: https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/118

Not bumping the package version because this isn't an urgent fix - it'll get released eventually.