### PR TITLE
Fix requires_auth decorator to handle no provided authorization header

### DIFF
--- a/cidc_api/auth.py
+++ b/cidc_api/auth.py
@@ -27,9 +27,9 @@ def requires_auth(resource: str, allowed_roles: list = []):
     def decorator(f):
         @wraps(f)
         def wrapped(*args, **kwargs):
-            if not request.headers.get("Authorization"):
-                app.auth.authenticate()
-            app.auth.authorized(allowed_roles, resource, request.method)
+            is_authorized = app.auth.authorized(allowed_roles, resource, request.method)
+            if not is_authorized:
+                raise Unauthorized("Please provide proper credentials")
             return f(*args, **kwargs)
 
         return wrapped

--- a/cidc_api/auth.py
+++ b/cidc_api/auth.py
@@ -27,6 +27,8 @@ def requires_auth(resource: str, allowed_roles: list = []):
     def decorator(f):
         @wraps(f)
         def wrapped(*args, **kwargs):
+            if not request.headers.get("Authorization"):
+                app.auth.authenticate()
             app.auth.authorized(allowed_roles, resource, request.method)
             return f(*args, **kwargs)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 from flask import _request_ctx_stack
 from werkzeug.exceptions import Unauthorized, BadRequest, PreconditionFailed
 
-from cidc_api.auth import BearerAuth
+from cidc_api.auth import BearerAuth, requires_auth
 from cidc_api.models import Users, CIDCRole
 
 from .test_models import db_test
@@ -33,6 +33,24 @@ throw_auth_error = make_raiser(Unauthorized("foo"))
 def bearer_auth(monkeypatch):
     monkeypatch.setattr("config.secrets.CloudStorageSecretManager", MagicMock)
     return BearerAuth()
+
+
+def test_requires_auth_current_user(app, monkeypatch):
+    """
+    Check that the requires_auth decorator ensures a current user
+    is available in the request context.
+    """
+
+    @app.route("/test")
+    @requires_auth("test")
+    def test_endpoint():
+        user = _request_ctx_stack.top.current_user
+
+    client = app.test_client()
+
+    # 401 when no authentication headers provided
+    response = client.get("/test")
+    assert response.status_code == 401
 
 
 def test_check_auth_smoketest(monkeypatch, app, bearer_auth):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -35,10 +35,10 @@ def bearer_auth(monkeypatch):
     return BearerAuth()
 
 
-def test_requires_auth_current_user(app, monkeypatch):
+def test_requires_auth_no_auth_headers(app, monkeypatch):
     """
-    Check that the requires_auth decorator ensures a current user
-    is available in the request context.
+    Check that the requires_auth decorator throws 401 when 
+    no authorization header is provided.
     """
 
     @app.route("/test")
@@ -48,7 +48,7 @@ def test_requires_auth_current_user(app, monkeypatch):
 
     client = app.test_client()
 
-    # 401 when no authentication headers provided
+    # 401 when no auth headers provided
     response = client.get("/test")
     assert response.status_code == 401
 


### PR DESCRIPTION
I discovered this bug while testing the `/users/self` endpoint. Making a GET request against `/users/self` with no authorization header was leading to 500s, because the `requires_auth` decorator was letting these requests get through to the `/users/self` endpoint function. Now, `requires_auth` will catch such requests and return 401.