### PR TITLE
code climate code coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - DEPLOY=gae
 install:
   - pip install -r requirements.dev.txt
+  - pip install pytest-cov
 before_script:
   - psql -c "create user cidcdev with password '1234'"
   - psql -c "create database cidctest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,15 @@ before_script:
   - psql -c "create database cidctest"
   - psql -c "grant all privileges on database cidctest to cidcdev"
   - psql cidctest -c "create extension citext"
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
-  - pytest
+  - pytest --cov=cidc_schemas -v
   - black --check cidc_api tests --target-version=py36
+after_script:
+  - coverage xml
+  - ./cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT 
 
 before_deploy:
   - if [ "$TRAVIS_BRANCH" = production ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:
-  - pytest --cov=cidc_schemas -v
+  - pytest --cov=cidc_api -v
   - black --check cidc_api tests --target-version=py36
 after_script:
   - coverage xml


### PR DESCRIPTION
Following some success with schemas coverage (see https://codeclimate.com/oss/dashboard)
I want to add such reporting to this repo as well, because it contains ~50% of the code of CIDC.