### PR TITLE
Fix cidc-api-modules

### DIFF
--- a/cidc_api/__init__.py
+++ b/cidc_api/__init__.py
@@ -1,1 +1,0 @@
-from .app import app

--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -1,4 +1,5 @@
 flask~=1.1.1
+flask-migrate==2.5.2
 flask-sqlalchemy~=2.4.0
 marshmallow-sqlalchemy==0.22.3
 google-cloud-storage~=1.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 flask-cors==3.0.8
-flask-migrate==2.5.2
 six==1.12.0
 python-jose==3.0.1
 psycopg2-binary==2.8.3

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,8 @@ setup(
     python_requires=">=3.6",
     install_requires=requirements,
     license="MIT license",
-    packages=["cidc_api.config"],
-    py_modules=["cidc_api.models", "cidc_api.gcloud_client", "cidc_api.emails"],
+    packages=["cidc_api.config", "cidc_api.models", "cidc_api.shared"],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.18.1",
+    version="0.18.2",
     zip_safe=False,
 )


### PR DESCRIPTION
Resolve issues leading to import errors for `cidc-api-modules>=0.18`