### PR TITLE
Improve (fix?) etag behavior

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
     license="MIT license",
     packages=["cidc_api.config", "cidc_api.models", "cidc_api.shared"],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.18.2",
+    version="0.18.3",
     zip_safe=False,
 )

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from cidc_api.app import app
 from cidc_api.models import (
-    CommonColumns,
     Users,
     TrialMetadata,
     UploadJobs,

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from cidc_api.app import app
 from cidc_api.models import (
+    CommonColumns,
     Users,
     TrialMetadata,
     UploadJobs,
@@ -42,6 +43,24 @@ EMAIL = "test@email.com"
 PROFILE = {"email": EMAIL}
 
 
+def test_common_compute_etag():
+    """Check that compute_etag excludes private fields"""
+
+    u = Users()
+
+    # Updates to private fields shouldn't change the etag
+    etag = u.compute_etag()
+    u._updated = datetime.now()
+    assert u.compute_etag() == etag
+
+    # Updates to public fields should change the etag
+    u.first_n = "foo"
+    new_etag = u.compute_etag()
+    assert new_etag != etag
+    u.first_n = "buzz"
+    assert u.compute_etag() != new_etag
+
+
 @db_test
 def test_common_insert(clean_db):
     """Test insert, inherited from CommonColumns"""
@@ -53,8 +72,9 @@ def test_common_insert(clean_db):
     # Insert a new record without disabling committing
     u2 = Users(email="b")
     u2.insert()
-    assert u1.id
-    assert u2.id
+    assert u1.id and u1._etag
+    assert u2.id and u2._etag
+    assert u1._etag != u2._etag
 
     assert Users.find_by_id(u1.id)
     assert Users.find_by_id(u2.id)
@@ -85,12 +105,23 @@ def test_common_update(clean_db):
     assert user.last_n == last_n
 
     _updated = user._updated
+    _etag = user._etag
 
     # Make sure you can clear a field to null
     user.update(changes={"first_n": None})
     user = Users.find_by_id(user.id)
     assert user._updated > _updated
+    assert _etag != user._etag
     assert user.first_n is None
+
+    _updated = user._updated
+    _etag = user._etag
+
+    # Make sure etags don't change if public fields don't change
+    user.update()
+    user = Users.find_by_id(user.id)
+    assert user._updated > _updated
+    assert _etag == user._etag
 
 
 @db_test

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -59,6 +59,9 @@ def test_common_compute_etag():
     u.first_n = "buzz"
     assert u.compute_etag() != new_etag
 
+    # Compute etag returns the same result if `u` doesn't change
+    assert u.compute_etag() == u.compute_etag()
+
 
 @db_test
 def test_common_insert(clean_db):


### PR DESCRIPTION
The way that #245 handled etag generation does not make sense. This PR fixes it by implementing the following behavior:
- only public columns are used to compute `_etag` values (columns that don't start with `_`)
- `_etag`s are only updated when the `CommonColumns.insert` and `CommonColumns.update` are used to modify a database record