### PR TITLE
Trial metadata validation and RBAC updates

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -28,6 +28,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import validates
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session
@@ -36,7 +37,7 @@ from sqlalchemy.sql import expression
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine.interfaces import ExecutionContext
 
-from cidc_schemas import prism, unprism
+from cidc_schemas import prism, unprism, json_validation
 
 from ..config.db import BaseModel
 from ..config.settings import (
@@ -345,6 +346,11 @@ class ValidationMultiError(Exception):
     pass
 
 
+trial_metadata_validator = json_validation.load_and_validate_schema(
+    "clinical_trial.json", return_validator=True
+)
+
+
 class TrialMetadata(CommonColumns):
     __tablename__ = "trial_metadata"
     # The CIMAC-determined trial id
@@ -353,6 +359,11 @@ class TrialMetadata(CommonColumns):
 
     # Create a GIN index on the metadata JSON blobs
     _metadata_idx = Index("metadata_idx", metadata_json, postgresql_using="gin")
+
+    @validates("metadata_json")
+    def validate_metadata_json(self, key, metadata_json):
+        trial_metadata_validator.validate(metadata_json)
+        return metadata_json
 
     @staticmethod
     @with_default_session

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -362,7 +362,10 @@ class TrialMetadata(CommonColumns):
 
     @validates("metadata_json")
     def validate_metadata_json(self, key, metadata_json):
-        trial_metadata_validator.validate(metadata_json)
+        errs = trial_metadata_validator.iter_errors(metadata_json)
+        messages = list(f"'metadata_json': {err.message}" for err in errs)
+        if messages:
+            raise ValidationMultiError(messages)
         return metadata_json
 
     @staticmethod

--- a/cidc_api/resources/trial_metadata.py
+++ b/cidc_api/resources/trial_metadata.py
@@ -22,9 +22,11 @@ trial_metadata_schema = TrialMetadataSchema()
 trial_metadata_list_schema = TrialMetadataListSchema()
 partial_trial_metadata_schema = TrialMetadataSchema(partial=True)
 
+trial_modifier_roles = [CIDCRole.ADMIN.value, CIDCRole.NCI_BIOBANK_USER.value]
+
 
 @trial_metadata_bp.route("/", methods=["GET"])
-@requires_auth("trial_metadata", [CIDCRole.ADMIN.value])
+@requires_auth("trial_metadata", trial_modifier_roles)
 @use_args_with_pagination({}, trial_metadata_schema)
 @marshal_response(trial_metadata_list_schema)
 def list_trial_metadata(args, pagination_args):
@@ -36,7 +38,7 @@ def list_trial_metadata(args, pagination_args):
 
 
 @trial_metadata_bp.route("/", methods=["POST"])
-@requires_auth("trial_metadata_item", [CIDCRole.ADMIN.value])
+@requires_auth("trial_metadata_item", trial_modifier_roles)
 @unmarshal_request(trial_metadata_schema, "trial")
 @marshal_response(trial_metadata_schema, 201)
 def create_trial_metadata(trial):
@@ -50,7 +52,7 @@ def create_trial_metadata(trial):
 
 
 @trial_metadata_bp.route("/<int:trial>", methods=["GET"])
-@requires_auth("trial_metadata_item", [CIDCRole.ADMIN.value])
+@requires_auth("trial_metadata_item", trial_modifier_roles)
 @lookup(TrialMetadata, "trial")
 @marshal_response(trial_metadata_schema)
 def get_trial_metadata(trial):
@@ -59,7 +61,7 @@ def get_trial_metadata(trial):
 
 
 @trial_metadata_bp.route("/<string:trial>", methods=["GET"])
-@requires_auth("trial_metadata_item", [CIDCRole.ADMIN.value])
+@requires_auth("trial_metadata_item", trial_modifier_roles)
 @lookup(TrialMetadata, "trial", find_func=TrialMetadata.find_by_trial_id)
 @marshal_response(trial_metadata_schema)
 def get_trial_metadata_by_trial_id(trial):
@@ -68,7 +70,7 @@ def get_trial_metadata_by_trial_id(trial):
 
 
 @trial_metadata_bp.route("/<int:trial>", methods=["PATCH"])
-@requires_auth("trial_metadata_item", [CIDCRole.ADMIN.value])
+@requires_auth("trial_metadata_item", trial_modifier_roles)
 @lookup(TrialMetadata, "trial", check_etag=True)
 @unmarshal_request(partial_trial_metadata_schema, "trial_updates", load_sqla=False)
 @marshal_response(trial_metadata_schema, 200)
@@ -80,7 +82,7 @@ def update_trial_metadata(trial, trial_updates):
 
 
 @trial_metadata_bp.route("/<string:trial>", methods=["PATCH"])
-@requires_auth("trial_metadata_item", [CIDCRole.ADMIN.value])
+@requires_auth("trial_metadata_item", trial_modifier_roles)
 @lookup(
     TrialMetadata, "trial", check_etag=True, find_func=TrialMetadata.find_by_trial_id
 )

--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -4,6 +4,6 @@ flask-sqlalchemy~=2.4.0
 marshmallow-sqlalchemy==0.22.3
 google-cloud-storage~=1.25.0
 google-cloud-pubsub==0.42.1
-cidc-schemas~=0.16.11
+cidc-schemas~=0.16.18
 python-dotenv==0.10.3
 requests==2.22.0

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -19,6 +19,7 @@ from cidc_api.models import (
     with_default_session,
     UploadJobStatus,
     NoResultFound,
+    ValidationMultiError,
 )
 from cidc_api.config.settings import (
     PAGINATION_PAGE_SIZE,
@@ -285,11 +286,11 @@ def test_create_trial_metadata(clean_db):
     assert trial.metadata_json == METADATA
 
     # Check that you can't insert a trial with invalid metadata
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationMultiError, match="'buzz' was unexpected"):
         TrialMetadata.create("foo", {"buzz": "bazz"})
 
-    with pytest.raises(Exception):
-        TrialMetadata("foo", {"buzz": "bazz"}).insert()
+    with pytest.raises(ValidationMultiError, match="'buzz' was unexpected"):
+        TrialMetadata(trial_id="foo", metadata_json={"buzz": "bazz"}).insert()
 
 
 @db_test

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -284,6 +284,13 @@ def test_create_trial_metadata(clean_db):
     assert trial
     assert trial.metadata_json == METADATA
 
+    # Check that you can't insert a trial with invalid metadata
+    with pytest.raises(Exception):
+        TrialMetadata.create("foo", {"buzz": "bazz"})
+
+    with pytest.raises(Exception):
+        TrialMetadata("foo", {"buzz": "bazz"}).insert()
+
 
 @db_test
 def test_trial_metadata_patch_manifest(clean_db):
@@ -546,7 +553,17 @@ def test_create_downloadable_file_from_blob(clean_db, monkeypatch):
     fake_blob.size = 5
     fake_blob.time_created = datetime.now()
 
-    clean_db.add(TrialMetadata(trial_id="id", metadata_json={}))
+    clean_db.add(
+        TrialMetadata(
+            trial_id="id",
+            metadata_json={
+                "protocol_identifier": "id",
+                "allowed_collection_event_names": [],
+                "allowed_cohort_names": [],
+                "participants": [],
+            },
+        )
+    )
     df = DownloadableFiles.create_from_blob(
         "id", "pbmc", "Shipping Manifest", fake_blob
     )

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import Tuple
 
-from cidc_schemas.prism import PROTOCOL_ID_FIELD_NAME
 from cidc_api.models import (
     Users,
     DownloadableFiles,
@@ -34,7 +33,12 @@ upload_types = ["olink", "cytof"]
 def setup_downloadable_files(cidc_api) -> Tuple[int, int]:
     """Insert two downloadable files into the database."""
     trial_id = "test-trial"
-    metadata_json = {PROTOCOL_ID_FIELD_NAME: trial_id, "participants": []}
+    metadata_json = {
+        "protocol_identifier": trial_id,
+        "allowed_collection_event_names": [],
+        "allowed_cohort_names": [],
+        "participants": [],
+    }
     trial = TrialMetadata(trial_id=trial_id, metadata_json=metadata_json)
 
     def make_file(object_url, upload_type, analysis_friendly) -> DownloadableFiles:

--- a/tests/resources/test_permissions.py
+++ b/tests/resources/test_permissions.py
@@ -38,7 +38,15 @@ def setup_permissions(cidc_api, monkeypatch) -> Tuple[int, int]:
         other_user.insert()
 
         # Create trial
-        TrialMetadata.create(TRIAL_ID, {})
+        TrialMetadata.create(
+            TRIAL_ID,
+            {
+                "protocol_identifier": TRIAL_ID,
+                "allowed_collection_event_names": [],
+                "allowed_cohort_names": [],
+                "participants": [],
+            },
+        )
 
         # Create permissions
         def create_permission(uid, assay):

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 from typing import Tuple
 
-from cidc_schemas.prism import PROTOCOL_ID_FIELD_NAME
+from cidc_api.resources.trial_metadata import trial_modifier_roles
 from cidc_api.models import Users, TrialMetadata, TrialMetadataSchema, CIDCRole
 
-from ..utils import mock_current_user, make_admin
+from ..utils import mock_current_user, make_role
 
 
 def setup_user(cidc_api, monkeypatch) -> int:
@@ -25,7 +25,12 @@ def setup_trial_metadata(cidc_api) -> Tuple[int, int]:
 
     def create_trial(n):
         trial_id = f"test-trial-{n}"
-        metadata_json = {PROTOCOL_ID_FIELD_NAME: trial_id, "participants": []}
+        metadata_json = {
+            "protocol_identifier": trial_id,
+            "participants": [],
+            "allowed_collection_event_names": [],
+            "allowed_cohort_names": [],
+        }
         trial = TrialMetadata(trial_id=trial_id, metadata_json=metadata_json)
         trial.insert()
         return trial.id
@@ -45,13 +50,15 @@ def test_list_trials(cidc_api, clean_db, monkeypatch):
     res = client.get("/trial_metadata")
     assert res.status_code == 401
 
-    # Admins can get all trials
-    make_admin(user_id, cidc_api)
-    res = client.get("/trial_metadata")
-    assert res.status_code == 200
-    assert len(res.json["_items"]) == 2
-    assert res.json["_meta"]["total"] == 2
-    assert set([t["id"] for t in res.json["_items"]]) == trial_ids
+    # Allowed users can get all trials
+    for role in trial_modifier_roles:
+        make_role(user_id, role, cidc_api)
+
+        res = client.get("/trial_metadata")
+        assert res.status_code == 200
+        assert len(res.json["_items"]) == 2
+        assert res.json["_meta"]["total"] == 2
+        assert set([t["id"] for t in res.json["_items"]]) == trial_ids
 
 
 def test_get_trial(cidc_api, clean_db, monkeypatch):
@@ -67,15 +74,16 @@ def test_get_trial(cidc_api, clean_db, monkeypatch):
     res = client.get(f"/trial_metadata/{trial_id}")
     assert res.status_code == 401
 
-    # Admins can get single trials
-    make_admin(user_id, cidc_api)
-    res = client.get(f"/trial_metadata/{trial_id}")
-    assert res.status_code == 200
-    assert res.json == TrialMetadataSchema().dump(trial)
+    # Allowed users can get single trials
+    for role in trial_modifier_roles:
+        make_role(user_id, role, cidc_api)
+        res = client.get(f"/trial_metadata/{trial_id}")
+        assert res.status_code == 200
+        assert res.json == TrialMetadataSchema().dump(trial)
 
-    # Getting non-existent trials yields 404
-    res = client.get(f"/trial_metadata/123212321")
-    assert res.status_code == 404
+        # Getting non-existent trials yields 404
+        res = client.get(f"/trial_metadata/123212321")
+        assert res.status_code == 404
 
 
 def test_get_trial_by_trial_id(cidc_api, clean_db, monkeypatch):
@@ -91,15 +99,16 @@ def test_get_trial_by_trial_id(cidc_api, clean_db, monkeypatch):
     res = client.get(f"/trial_metadata/{trial.trial_id}")
     assert res.status_code == 401
 
-    # Admins can get single trials
-    make_admin(user_id, cidc_api)
-    res = client.get(f"/trial_metadata/{trial.trial_id}")
-    assert res.status_code == 200
-    assert res.json == TrialMetadataSchema().dump(trial)
+    # Allowed users can get single trials
+    for role in trial_modifier_roles:
+        make_role(user_id, role, cidc_api)
+        res = client.get(f"/trial_metadata/{trial.trial_id}")
+        assert res.status_code == 200
+        assert res.json == TrialMetadataSchema().dump(trial)
 
-    # Getting non-existent trials yields 404
-    res = client.get(f"/trial_metadata/foobar")
-    assert res.status_code == 404
+        # Getting non-existent trials yields 404
+        res = client.get(f"/trial_metadata/foobar")
+        assert res.status_code == 404
 
 
 def test_create_trial(cidc_api, clean_db, monkeypatch):
@@ -108,7 +117,12 @@ def test_create_trial(cidc_api, clean_db, monkeypatch):
     trial_id = "test-trial"
     trial_json = {
         "trial_id": trial_id,
-        "metadata_json": {PROTOCOL_ID_FIELD_NAME: trial_id, "participants": []},
+        "metadata_json": {
+            "protocol_identifier": trial_id,
+            "participants": [],
+            "allowed_collection_event_names": [],
+            "allowed_cohort_names": [],
+        },
     }
 
     client = cidc_api.test_client()
@@ -117,15 +131,20 @@ def test_create_trial(cidc_api, clean_db, monkeypatch):
     res = client.post("/trial_metadata", json=trial_json)
     assert res.status_code == 401
 
-    # Admins can create trials
-    make_admin(user_id, cidc_api)
-    res = client.post("/trial_metadata", json=trial_json)
-    assert res.status_code == 201
-    assert {**res.json, **trial_json} == res.json
+    # Allowed users can create trials
+    for role in trial_modifier_roles:
+        make_role(user_id, role, cidc_api)
+        res = client.post("/trial_metadata", json=trial_json)
+        assert res.status_code == 201
+        assert {**res.json, **trial_json} == res.json
 
-    # No two trials can have the same trial_id
-    res = client.post("/trial_metadata", json=trial_json)
-    assert res.status_code == 400
+        # No two trials can have the same trial_id
+        res = client.post("/trial_metadata", json=trial_json)
+        assert res.status_code == 400
+
+        with cidc_api.app_context():
+            trial = TrialMetadata.find_by_trial_id(trial_id)
+            trial.delete()
 
 
 def test_update_trial(cidc_api, clean_db, monkeypatch):
@@ -141,24 +160,32 @@ def test_update_trial(cidc_api, clean_db, monkeypatch):
     res = client.patch(f"/trial_metadata/{trial_id}")
     assert res.status_code == 401
 
-    make_admin(user_id, cidc_api)
+    for role in trial_modifier_roles:
+        make_role(user_id, role, cidc_api)
 
-    # A missing ETag blocks an update
-    res = client.patch(f"/trial_metadata/{trial_id}")
-    assert res.status_code == 428
+        # A missing ETag blocks an update
+        res = client.patch(f"/trial_metadata/{trial_id}")
+        assert res.status_code == 428
 
-    # An incorrect ETag blocks an update
-    res = client.patch(f"/trial_metadata/{trial_id}", headers={"If-Match": "foo"})
-    assert res.status_code == 412
+        # An incorrect ETag blocks an update
+        res = client.patch(f"/trial_metadata/{trial_id}", headers={"If-Match": "foo"})
+        assert res.status_code == 412
 
-    # An admin can successfully update a trial
-    new_metadata_json = {"foo": "bar"}
-    res = client.patch(
-        f"/trial_metadata/{trial_id}",
-        headers={"If-Match": trial._etag},
-        json={"metadata_json": new_metadata_json},
-    )
-    assert res.status_code == 200
-    assert res.json["id"] == trial.id
-    assert res.json["trial_id"] == trial.trial_id
-    assert res.json["metadata_json"] == new_metadata_json
+        # An admin can successfully update a trial
+        new_metadata_json = {
+            **trial.metadata_json,
+            "allowed_collection_event_names": ["bazz"],
+            "allowed_cohort_names": ["buzz"],
+        }
+        res = client.patch(
+            f"/trial_metadata/{trial_id}",
+            headers={"If-Match": trial._etag},
+            json={"metadata_json": new_metadata_json},
+        )
+        assert res.status_code == 200
+        assert res.json["id"] == trial.id
+        assert res.json["trial_id"] == trial.trial_id
+        assert res.json["metadata_json"] == new_metadata_json
+
+        with cidc_api.app_context():
+            trial = TrialMetadata.find_by_id(trial_id)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,11 +54,27 @@ users["additional_records"] = [
 ]
 
 trial_metadata = {
-    "json": {"id": TEST_RECORD_ID, "trial_id": "foo", "metadata_json": {}},
+    "json": {
+        "id": TEST_RECORD_ID,
+        "trial_id": "foo",
+        "metadata_json": {
+            "protocol_identifier": "foo",
+            "allowed_collection_event_names": [],
+            "allowed_cohort_names": [],
+            "participants": [],
+        },
+    },
     "model": TrialMetadata,
     "allowed_methods": {"POST", "PATCH", "GET"},
     "lookup_field": "trial_id",
-    "PATCH_json": {"metadata_json": {"foo": "bar"}},
+    "PATCH_json": {
+        "metadata_json": {
+            "protocol_identifier": "foo",
+            "allowed_collection_event_names": ["bar"],
+            "allowed_cohort_names": ["buzz"],
+            "participants": [],
+        }
+    },
 }
 
 downloadable_files = {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,12 @@ def mock_current_user(user: Users, monkeypatch):
 
 def make_admin(user_id, app):
     """Update the user with id `user_id`'s role to cidc-admin."""
+    make_role(user_id, CIDCRole.ADMIN.value, app)
+
+
+def make_role(user_id, role, app):
+    """Update the user with id `user_id`'s role to `role`."""
     with app.app_context():
         user = Users.find_by_id(user_id)
-        user.role = CIDCRole.ADMIN.value
+        user.role = role
         user.update()


### PR DESCRIPTION
This PR:
* adds automatic cidc-schemas validation on the `TrialMetadata.metadata_json` field
* adds NCI biobank user permission on `/trial_metadata` resource endpoints