### PR TITLE
Remove trial lookup by db record id

### DIFF
--- a/cidc_api/resources/trial_metadata.py
+++ b/cidc_api/resources/trial_metadata.py
@@ -51,33 +51,12 @@ def create_trial_metadata(trial):
     return trial
 
 
-@trial_metadata_bp.route("/<int:trial>", methods=["GET"])
-@requires_auth("trial_metadata_item", trial_modifier_roles)
-@lookup(TrialMetadata, "trial")
-@marshal_response(trial_metadata_schema)
-def get_trial_metadata(trial):
-    """Get one trial metadata record by ID."""
-    return trial
-
-
 @trial_metadata_bp.route("/<string:trial>", methods=["GET"])
 @requires_auth("trial_metadata_item", trial_modifier_roles)
 @lookup(TrialMetadata, "trial", find_func=TrialMetadata.find_by_trial_id)
 @marshal_response(trial_metadata_schema)
 def get_trial_metadata_by_trial_id(trial):
     """Get one trial metadata record by trial identifier."""
-    return trial
-
-
-@trial_metadata_bp.route("/<int:trial>", methods=["PATCH"])
-@requires_auth("trial_metadata_item", trial_modifier_roles)
-@lookup(TrialMetadata, "trial", check_etag=True)
-@unmarshal_request(partial_trial_metadata_schema, "trial_updates", load_sqla=False)
-@marshal_response(trial_metadata_schema, 200)
-def update_trial_metadata(trial, trial_updates):
-    """Update an existing trial metadata record."""
-    trial.update(changes=trial_updates)
-
     return trial
 
 

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -64,9 +64,10 @@ def test_list_trials(cidc_api, clean_db, monkeypatch):
 def test_get_trial(cidc_api, clean_db, monkeypatch):
     """Check that getting a single trial works as expected"""
     user_id = setup_user(cidc_api, monkeypatch)
-    trial_id, _ = set(setup_trial_metadata(cidc_api))
+    trial_record_id, _ = set(setup_trial_metadata(cidc_api))
     with cidc_api.app_context():
-        trial = TrialMetadata.find_by_id(trial_id)
+        trial = TrialMetadata.find_by_id(trial_record_id)
+        trial_id = trial.trial_id
 
     client = cidc_api.test_client()
 
@@ -169,30 +170,33 @@ def test_create_trial(cidc_api, clean_db, monkeypatch):
 def test_update_trial(cidc_api, clean_db, monkeypatch):
     """Check that updating a trial works as expected"""
     user_id = setup_user(cidc_api, monkeypatch)
-    trial_id, _ = set(setup_trial_metadata(cidc_api))
+    trial_record_id, _ = set(setup_trial_metadata(cidc_api))
     with cidc_api.app_context():
-        trial = TrialMetadata.find_by_id(trial_id)
+        trial = TrialMetadata.find_by_id(trial_record_id)
 
     client = cidc_api.test_client()
 
     # Non-admins can't update single trials
-    res = client.patch(f"/trial_metadata/{trial_id}")
+    res = client.patch(f"/trial_metadata/{trial.trial_id}")
     assert res.status_code == 401
 
     for role in trial_modifier_roles:
         make_role(user_id, role, cidc_api)
 
         # A missing ETag blocks an update
-        res = client.patch(f"/trial_metadata/{trial_id}")
+        res = client.patch(f"/trial_metadata/{trial.trial_id}")
         assert res.status_code == 428
 
         # An incorrect ETag blocks an update
-        res = client.patch(f"/trial_metadata/{trial_id}", headers={"If-Match": "foo"})
+        res = client.patch(
+            f"/trial_metadata/{trial.trial_id}", headers={"If-Match": "foo"}
+        )
         assert res.status_code == 412
 
         # No trial can be updated to have invalid metadata
+        print(trial._etag)
         res = client.patch(
-            f"/trial_metadata/{trial_id}",
+            f"/trial_metadata/{trial.trial_id}",
             headers={"If-Match": trial._etag},
             json={"metadata_json": bad_trial_json["metadata_json"]},
         )
@@ -206,7 +210,7 @@ def test_update_trial(cidc_api, clean_db, monkeypatch):
             "allowed_cohort_names": ["buzz"],
         }
         res = client.patch(
-            f"/trial_metadata/{trial_id}",
+            f"/trial_metadata/{trial.trial_id}",
             headers={"If-Match": trial._etag},
             json={"metadata_json": new_metadata_json},
         )
@@ -216,4 +220,4 @@ def test_update_trial(cidc_api, clean_db, monkeypatch):
         assert res.json["metadata_json"] == new_metadata_json
 
         with cidc_api.app_context():
-            trial = TrialMetadata.find_by_id(trial_id)
+            trial = TrialMetadata.find_by_id(trial.id)

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -67,18 +67,17 @@ def test_get_trial(cidc_api, clean_db, monkeypatch):
     trial_record_id, _ = set(setup_trial_metadata(cidc_api))
     with cidc_api.app_context():
         trial = TrialMetadata.find_by_id(trial_record_id)
-        trial_id = trial.trial_id
 
     client = cidc_api.test_client()
 
     # Non-admins can't get single trials
-    res = client.get(f"/trial_metadata/{trial_id}")
+    res = client.get(f"/trial_metadata/{trial.trial_id}")
     assert res.status_code == 401
 
     # Allowed users can get single trials
     for role in trial_modifier_roles:
         make_role(user_id, role, cidc_api)
-        res = client.get(f"/trial_metadata/{trial_id}")
+        res = client.get(f"/trial_metadata/{trial.trial_id}")
         assert res.status_code == 200
         assert res.json == TrialMetadataSchema().dump(trial)
 
@@ -194,7 +193,6 @@ def test_update_trial(cidc_api, clean_db, monkeypatch):
         assert res.status_code == 412
 
         # No trial can be updated to have invalid metadata
-        print(trial._etag)
         res = client.patch(
             f"/trial_metadata/{trial.trial_id}",
             headers={"If-Match": trial._etag},

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -404,7 +404,6 @@ def test_endpoint_urls(cidc_api):
         "/permissions/",
         "/permissions/<int:permission>",
         "/trial_metadata/",
-        "/trial_metadata/<int:trial>",
         "/trial_metadata/<string:trial>",
         "/upload_jobs/",
         "/upload_jobs/<int:upload_job>",


### PR DESCRIPTION
Allowing trial lookup either by database record id or by protocol id was causing buggy behavior on fully numerical protocol identifiers, since such protocol identifiers were treated as record ids by the API. 

This PR removes trial lookup by record id, making it possible to look up trials only using protocol identifiers. No API clients perform lookups using record ids, so this isn't a breaking change.