### PR TITLE
Fix permissions endpoint

### DIFF
--- a/cidc_api/resources/permissions.py
+++ b/cidc_api/resources/permissions.py
@@ -28,7 +28,7 @@ permission_list_schema = PermissionListSchema()
 
 @permissions_bp.route("/", methods=["GET"])
 @requires_auth("permissions")
-@use_args({"user_id": fields.Str()}, location="query")
+@use_args({"user_id": fields.Int()}, location="query")
 @marshal_response(permission_list_schema)
 def list_permissions(args: dict):
     """

--- a/tests/resources/test_permissions.py
+++ b/tests/resources/test_permissions.py
@@ -71,7 +71,7 @@ def test_list_permissions(cidc_api, clean_db, monkeypatch):
     client = cidc_api.test_client()
 
     # Check that user can get their own permissions
-    res = client.get("permissions")
+    res = client.get(f"permissions?user_id={current_user_id}")
     assert res.status_code == 200
     assert len(res.json["_items"]) == 2
     assert res.json["_meta"]["total"] == 2


### PR DESCRIPTION
This query param parsing bug currently prevents non-admin users from viewing their own permissions on staging and production (if you open the network tab in the developer console, you'll see 401 errors).