### PR TITLE
Explicit filter facets

### DIFF
--- a/cidc_api/models/facets.py
+++ b/cidc_api/models/facets.py
@@ -1,0 +1,116 @@
+from typing import Dict, List, Optional
+
+from sqlalchemy.sql import ClauseElement
+
+from .models import DownloadableFiles
+
+like = DownloadableFiles.object_url.like
+
+# Represent available downloadable file assay facets as a dictionary
+# mapping an assay names to assay subfacet dictionaries. An assay subfacet
+# dictionary maps subfacet names to a list of SQLAlchemy filter clause elements
+# for looking up files associated with the given subfacet.
+assay_facets: Dict[str, Dict[str, List[ClauseElement]]] = {
+    "cytof": {
+        "source": [
+            like("%source_%.fcs"),
+            like("%spike_in_fcs.fcs"),
+            like("%normalized_and_debarcoded.fcs"),
+            like("%processed.fcs"),
+        ],
+        "cell counts": [
+            like("%cell_counts_assignment.csv"),
+            like("%cell_counts_compartment.csv"),
+            like("%cell_counts_profiling.csv"),
+        ],
+        "labeled source": [like("%source.fcs")],
+        "analysis results": [like("%analysis.zip"), like("%results.zip")],
+        "key": [
+            like("%assignment.csv"),
+            like("%compartment.csv"),
+            like("%profiling.csv"),
+        ],
+    },
+    "wes": {
+        "source": [
+            like("%wes%reads_%.bam"),
+            like("%wes%r1_%.fastq.gz"),
+            like("%wes%r2_%.fastq.gz"),
+        ],
+        "germline": [like("%vcfcompare.txt"), like("%optimalpurityvalue.txt")],
+        "clonality": [like("%clonality_pyclone.tsv")],
+        "copy number": [
+            like("%copynumber_cnvcalls.txt"),
+            like("%copynumber_cnvcalls.txt.tn.tsv"),
+        ],
+        "neoantigen": [
+            like("%MHC_Class_I_all_epitopes.tsv"),
+            like("%MHC_Class_I_filtered_condensed_ranked.tsv"),
+            like("%MHC_Class_II_all_epitopes.tsv"),
+            like("%MHC_Class_II_filtered_condensed_ranked.tsv"),
+        ],
+        "somatic": [
+            like("%vcf_tnscope_output.vcf"),
+            like("%maf_tnscope_output.maf"),
+            like("%vcf_tnscope_filter.vcf"),
+            like("%maf_tnscope_filter.maf"),
+            like("%tnscope_exons_broad.gz"),
+            like("%tnscope_exons_mda.gz"),
+            like("%tnscope_exons_mocha.gz"),
+        ],
+        "alignment": [
+            like("%tn_corealigned.bam"),
+            like("%tn_corealigned.bam.bai"),
+            like("%recalibrated.bam"),
+            like("%recalibrated.bam.bai"),
+            like("%sorted.dedup.bam"),
+            like("%sorted.dedup.bam.bai"),
+        ],
+        "metrics": [
+            like("%all_sample_summaries.txt"),
+            like("%coverage_metrics.txt"),
+            like("%target_metrics.txt"),
+            like("%coverage_metrics_summary.txt"),
+            like("%target_metrics_summary.txt"),
+            like("%mosdepth_region_dist_broad.txt"),
+            like("%mosdepth_region_dist_mda.txt"),
+            like("%mosdepth_region_dist_mocha.txt"),
+            like("%optitype_result.tsv"),
+        ],
+        "hla type": [like("%optitype_result.tsv")],
+        "report": [like("%wes_version.txt")],
+    },
+    "rna": {
+        "source": [
+            like("%rna%reads_%.bam"),
+            like("%rna%r1_%.fastq.gz"),
+            like("%rna%r2_%.fastq.gz"),
+        ],
+        "alignment": [
+            like("%sorted.bam"),
+            like("%sorted.bam.bai"),
+            like("%sorted.bam.stat.txt"),
+            like("%downsampling.bam"),
+            like("%downsampling.bam.bai"),
+        ],
+        "quality": [
+            like("%downsampling_housekeeping.bam"),
+            like("%downsampling_housekeeping.bam.bai"),
+            like("%read_distrib.txt"),
+            like("%tin_score.txt"),
+            like("%tin_score.summary.txt"),
+        ],
+        "gene quantification": [
+            like("%quant.sf"),
+            like("%transcriptome.bam.log"),
+            like("%aux_info_ambig_info.tsv"),
+            like("%aux_info_expected_bias.gz"),
+            like("%aux_info_fld.gz"),
+            like("%aux_info_meta_info.json"),
+            like("%aux_info_observed_bias.gz"),
+            like("%aux_info_observed_bias_3p.gz"),
+            like("%cmd_info.json"),
+            like("%salmon_quant.log"),
+        ],
+    },
+}

--- a/cidc_api/models/facets.py
+++ b/cidc_api/models/facets.py
@@ -1,116 +1,139 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
+from werkzeug.exceptions import BadRequest
 from sqlalchemy.sql import ClauseElement
 
-from .models import DownloadableFiles
-
-like = DownloadableFiles.object_url.like
+Facets = Dict[str, Union[List[str], Dict[str, List[str]]]]
 
 # Represent available downloadable file assay facets as a dictionary
 # mapping an assay names to assay subfacet dictionaries. An assay subfacet
 # dictionary maps subfacet names to a list of SQLAlchemy filter clause elements
 # for looking up files associated with the given subfacet.
-assay_facets: Dict[str, Dict[str, List[ClauseElement]]] = {
-    "cytof": {
-        "source": [
-            like("%source_%.fcs"),
-            like("%spike_in_fcs.fcs"),
-            like("%normalized_and_debarcoded.fcs"),
-            like("%processed.fcs"),
+assay_facets: Facets = {
+    "CyTOF": {
+        "Source": [
+            "%source_%.fcs",
+            "%spike_in_fcs.fcs",
+            "%normalized_and_debarcoded.fcs",
+            "%processed.fcs",
         ],
-        "cell counts": [
-            like("%cell_counts_assignment.csv"),
-            like("%cell_counts_compartment.csv"),
-            like("%cell_counts_profiling.csv"),
+        "Cell Counts": [
+            "%cell_counts_assignment.csv",
+            "%cell_counts_compartment.csv",
+            "%cell_counts_profiling.csv",
         ],
-        "labeled source": [like("%source.fcs")],
-        "analysis results": [like("%analysis.zip"), like("%results.zip")],
-        "key": [
-            like("%assignment.csv"),
-            like("%compartment.csv"),
-            like("%profiling.csv"),
-        ],
+        "Labeled Source": ["%source.fcs"],
+        "Analysis Results": ["%analysis.zip", "%results.zip"],
+        "Key": ["%assignment.csv", "%compartment.csv", "%profiling.csv"],
     },
-    "wes": {
-        "source": [
-            like("%wes%reads_%.bam"),
-            like("%wes%r1_%.fastq.gz"),
-            like("%wes%r2_%.fastq.gz"),
+    "WES": {
+        "Source": ["%wes%reads_%.bam", "%wes%r1_%.fastq.gz", "%wes%r2_%.fastq.gz"],
+        "Germline": ["%vcfcompare.txt", "%optimalpurityvalue.txt"],
+        "Clonality": ["%clonality_pyclone.tsv"],
+        "Copy Number": ["%copynumber_cnvcalls.txt", "%copynumber_cnvcalls.txt.tn.tsv"],
+        "Neoantigen": [
+            "%MHC_Class_I_all_epitopes.tsv",
+            "%MHC_Class_I_filtered_condensed_ranked.tsv",
+            "%MHC_Class_II_all_epitopes.tsv",
+            "%MHC_Class_II_filtered_condensed_ranked.tsv",
         ],
-        "germline": [like("%vcfcompare.txt"), like("%optimalpurityvalue.txt")],
-        "clonality": [like("%clonality_pyclone.tsv")],
-        "copy number": [
-            like("%copynumber_cnvcalls.txt"),
-            like("%copynumber_cnvcalls.txt.tn.tsv"),
+        "Somatic": [
+            "%vcf_tnscope_output.vcf",
+            "%maf_tnscope_output.maf",
+            "%vcf_tnscope_filter.vcf",
+            "%maf_tnscope_filter.maf",
+            "%tnscope_exons_broad.gz",
+            "%tnscope_exons_mda.gz",
+            "%tnscope_exons_mocha.gz",
         ],
-        "neoantigen": [
-            like("%MHC_Class_I_all_epitopes.tsv"),
-            like("%MHC_Class_I_filtered_condensed_ranked.tsv"),
-            like("%MHC_Class_II_all_epitopes.tsv"),
-            like("%MHC_Class_II_filtered_condensed_ranked.tsv"),
+        "Alignment": [
+            "%tn_corealigned.bam",
+            "%tn_corealigned.bam.bai",
+            "%recalibrated.bam",
+            "%recalibrated.bam.bai",
+            "%sorted.dedup.bam",
+            "%sorted.dedup.bam.bai",
         ],
-        "somatic": [
-            like("%vcf_tnscope_output.vcf"),
-            like("%maf_tnscope_output.maf"),
-            like("%vcf_tnscope_filter.vcf"),
-            like("%maf_tnscope_filter.maf"),
-            like("%tnscope_exons_broad.gz"),
-            like("%tnscope_exons_mda.gz"),
-            like("%tnscope_exons_mocha.gz"),
+        "Metrics": [
+            "%all_sample_summaries.txt",
+            "%coverage_metrics.txt",
+            "%target_metrics.txt",
+            "%coverage_metrics_summary.txt",
+            "%target_metrics_summary.txt",
+            "%mosdepth_region_dist_broad.txt",
+            "%mosdepth_region_dist_mda.txt",
+            "%mosdepth_region_dist_mocha.txt",
+            "%optitype_result.tsv",
         ],
-        "alignment": [
-            like("%tn_corealigned.bam"),
-            like("%tn_corealigned.bam.bai"),
-            like("%recalibrated.bam"),
-            like("%recalibrated.bam.bai"),
-            like("%sorted.dedup.bam"),
-            like("%sorted.dedup.bam.bai"),
-        ],
-        "metrics": [
-            like("%all_sample_summaries.txt"),
-            like("%coverage_metrics.txt"),
-            like("%target_metrics.txt"),
-            like("%coverage_metrics_summary.txt"),
-            like("%target_metrics_summary.txt"),
-            like("%mosdepth_region_dist_broad.txt"),
-            like("%mosdepth_region_dist_mda.txt"),
-            like("%mosdepth_region_dist_mocha.txt"),
-            like("%optitype_result.tsv"),
-        ],
-        "hla type": [like("%optitype_result.tsv")],
-        "report": [like("%wes_version.txt")],
+        "HLA Type": ["%optitype_result.tsv"],
+        "Report": ["%wes_version.txt"],
     },
-    "rna": {
-        "source": [
-            like("%rna%reads_%.bam"),
-            like("%rna%r1_%.fastq.gz"),
-            like("%rna%r2_%.fastq.gz"),
+    "RNA": {
+        "Source": ["%rna%reads_%.bam", "%rna%r1_%.fastq.gz", "%rna%r2_%.fastq.gz"],
+        "Alignment": [
+            "%sorted.bam",
+            "%sorted.bam.bai",
+            "%sorted.bam.stat.txt",
+            "%downsampling.bam",
+            "%downsampling.bam.bai",
         ],
-        "alignment": [
-            like("%sorted.bam"),
-            like("%sorted.bam.bai"),
-            like("%sorted.bam.stat.txt"),
-            like("%downsampling.bam"),
-            like("%downsampling.bam.bai"),
+        "Quality": [
+            "%downsampling_housekeeping.bam",
+            "%downsampling_housekeeping.bam.bai",
+            "%read_distrib.txt",
+            "%tin_score.txt",
+            "%tin_score.summary.txt",
         ],
-        "quality": [
-            like("%downsampling_housekeeping.bam"),
-            like("%downsampling_housekeeping.bam.bai"),
-            like("%read_distrib.txt"),
-            like("%tin_score.txt"),
-            like("%tin_score.summary.txt"),
-        ],
-        "gene quantification": [
-            like("%quant.sf"),
-            like("%transcriptome.bam.log"),
-            like("%aux_info_ambig_info.tsv"),
-            like("%aux_info_expected_bias.gz"),
-            like("%aux_info_fld.gz"),
-            like("%aux_info_meta_info.json"),
-            like("%aux_info_observed_bias.gz"),
-            like("%aux_info_observed_bias_3p.gz"),
-            like("%cmd_info.json"),
-            like("%salmon_quant.log"),
+        "Gene Quantification": [
+            "%quant.sf",
+            "%transcriptome.bam.log",
+            "%aux_info_ambig_info.tsv",
+            "%aux_info_expected_bias.gz",
+            "%aux_info_fld.gz",
+            "%aux_info_meta_info.json",
+            "%aux_info_observed_bias.gz",
+            "%aux_info_observed_bias_3p.gz",
+            "%cmd_info.json",
+            "%salmon_quant.log",
         ],
     },
 }
+
+clinical_facets: Facets = {
+    "Participants Info": ["%participants.csv"],
+    "Samples Info": ["%samples.csv"],
+}
+
+facets = {"Assay Type": assay_facets, "Clinical Type": clinical_facets}
+
+
+def get_facet_labels():
+    return {
+        "Assay Type": {
+            assay_name: list(subfacets.keys())
+            for assay_name, subfacets in assay_facets.items()
+        },
+        "Clinical Type": list(clinical_facets.keys()),
+    }
+
+
+def get_facets_for_paths(
+    object_url_like: ClauseElement, paths: List[List[str]]
+) -> List[ClauseElement]:
+    clause_args: List[ClauseElement] = []
+    for path in paths:
+        try:
+            if len(path) == 2:
+                path_clauses = facets[path[0]][path[1]]
+            if len(path) == 3:
+                subfacets = facets[path[0]][path[1]]
+                if not isinstance(subfacets, dict):
+                    raise Exception
+                path_clauses = subfacets[path[2]]
+        except:
+            raise BadRequest(f"no facet for path {path}")
+
+        clause_args.extend(path_clauses)
+
+    clauses = [object_url_like(clause_arg) for clause_arg in clause_args]
+    return clauses

--- a/cidc_api/models/facets.py
+++ b/cidc_api/models/facets.py
@@ -123,16 +123,13 @@ def get_facets_for_paths(
     clause_args: List[ClauseElement] = []
     for path in paths:
         try:
-            if len(path) == 2:
-                path_clauses = facets[path[0]][path[1]]
-            if len(path) == 3:
-                subfacets = facets[path[0]][path[1]]
-                if not isinstance(subfacets, dict):
-                    raise Exception
-                path_clauses = subfacets[path[2]]
-        except:
+            assert len(path) in (2, 3)
+            path_clauses = facets
+            for key in path:
+                path_clauses = path_clauses[key]
+            assert isinstance(path_clauses, list)
+        except Exception as e:
             raise BadRequest(f"no facet for path {path}")
-
         clause_args.extend(path_clauses)
 
     clauses = [object_url_like(clause_arg) for clause_arg in clause_args]

--- a/cidc_api/resources/downloadable_files.py
+++ b/cidc_api/resources/downloadable_files.py
@@ -11,6 +11,7 @@ from ..models import (
     DownloadableFileSchema,
     DownloadableFileListSchema,
     Permissions,
+    facets,
 )
 from ..shared import gcloud_client
 from ..shared.auth import get_current_user, requires_auth
@@ -27,16 +28,15 @@ downloadable_files_schema = DownloadableFileSchema()
 downloadable_files_list_schema = DownloadableFileListSchema()
 
 
-file_filter_params = {
-    "trial_ids": fields.DelimitedList(fields.Str(), default=[]),
-    "upload_types": fields.DelimitedList(fields.Str(), default=[]),
-    "analysis_friendly": fields.Bool(default=False),
+file_filter_schema = {
+    "trial_ids": fields.DelimitedList(fields.Str),
+    "facets": fields.DelimitedList(fields.DelimitedList(fields.Str, delimiter="|")),
 }
 
 
 @downloadable_files_bp.route("/", methods=["GET"])
 @requires_auth("downloadable_files")
-@use_args_with_pagination(file_filter_params, downloadable_files_schema)
+@use_args_with_pagination(file_filter_schema, downloadable_files_schema)
 @marshal_response(downloadable_files_list_schema)
 def list_downloadable_files(args, pagination_args):
     """List downloadable files that the current user is allowed to view."""
@@ -115,16 +115,6 @@ def get_filter_facets():
         ...
     }
     """
-    user = get_current_user()
+    trial_ids = DownloadableFiles.get_distinct("trial_id")
 
-    if user.is_admin():
-        # Admins can facet on every trial or upload type
-        trial_ids = DownloadableFiles.get_distinct("trial_id")
-        upload_types = DownloadableFiles.get_distinct("upload_type")
-    else:
-        # Non-admins can only facet on what they have permission to view
-        user_filter = lambda q: q.filter(Permissions.granted_to_user == user.id)
-        trial_ids = Permissions.get_distinct("trial_id", filter_=user_filter)
-        upload_types = Permissions.get_distinct("upload_type", filter_=user_filter)
-
-    return jsonify({"trial_id": trial_ids, "upload_type": upload_types})
+    return jsonify({"trial_ids": trial_ids, "facets": facets.get_facet_labels()})

--- a/tests/models/test_facets.py
+++ b/tests/models/test_facets.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+
+import pytest
+from werkzeug.exceptions import BadRequest
+
+from cidc_api.models.facets import facets, get_facet_labels, get_facets_for_paths
+
+
+def test_get_facet_labels():
+    """Ensure get_facet_labels returns an object with the expected structure."""
+    labels = get_facet_labels()
+    for value in labels.values():
+        if isinstance(value, dict):
+            for subvalue in value.values():
+                assert isinstance(subvalue, list)
+        else:
+            assert isinstance(value, list)
+
+
+def test_get_facets_for_paths():
+    """Test that get_facets_for_paths works as expected."""
+    mock_like = lambda v: v
+
+    assert get_facets_for_paths(mock_like, []) == []
+
+    # Existing paths
+    good_paths = [
+        ["Assay Type", "WES", "Somatic"],
+        ["Assay Type", "RNA", "Quality"],
+        ["Clinical Type", "Participants Info"],
+    ]
+    facets_for_paths = get_facets_for_paths(mock_like, good_paths)
+    assert facets_for_paths == [
+        *facets["Assay Type"]["WES"]["Somatic"],
+        *facets["Assay Type"]["RNA"]["Quality"],
+        *facets["Clinical Type"]["Participants Info"],
+    ]
+
+    # Non-existent paths
+    bad_paths = [
+        ["foo"],
+        ["Assay Type"],
+        ["Assay Type", "WES"],
+        ["Clinical Type", "Participants Info", "Foo"],
+    ]
+    for path in bad_paths:
+        with pytest.raises(BadRequest, match=f"no facet for path"):
+            get_facets_for_paths(mock_like, [path])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -83,9 +83,9 @@ downloadable_files = {
         "id": TEST_RECORD_ID,
         "trial_id": trial_metadata["json"]["trial_id"],
         "file_name": "",
-        "upload_type": "olink",
+        "upload_type": "rna",
         "data_format": "",
-        "object_url": "",
+        "object_url": f'{trial_metadata["json"]["trial_id"]}/rna/.../r1_123.fastq.gz',
         "uploaded_timestamp": datetime.now(),
         "file_size_bytes": 1,
     },
@@ -96,11 +96,11 @@ downloadable_files = {
     "filters": {
         "empty": {
             "trial_ids": [trial_metadata["json"]["trial_id"]],
-            "upload_types": ["not_olink"],
+            "facets": "Clinical Type|Participants Info",
         },
         "one": {
             "trial_ids": [trial_metadata["json"]["trial_id"]],
-            "upload_types": ["olink"],
+            "facets": "Assay Type|RNA|Source",
         },
     },
 }


### PR DESCRIPTION
Rather than inferring the filter facet hierarchy from GCS URIs, use a dictionary mapping facets to SQLAlchemy filter clauses.