### PR TITLE
Add catch-all facets for olink, ihc, and mif

### DIFF
--- a/cidc_api/models/facets.py
+++ b/cidc_api/models/facets.py
@@ -141,6 +141,9 @@ assay_facets: Facets = {
             ]
         ),
     },
+    "Olink": {"All Olink Files": FacetConfig(["%/olink%"])},
+    "IHC": {"All IHC Files": FacetConfig(["%/ihc%"])},
+    "mIF": {"All mIF Files": FacetConfig(["%/mif%"])},
 }
 
 clinical_facets: Facets = {


### PR DESCRIPTION
...placeholder to allow users to access files for these assays until we model file categories for these assays.