### PR TITLE
Add facet group column to DownloadableFiles and generate facet groups for existing file records

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -741,6 +741,7 @@ class DownloadableFiles(CommonColumns):
     file_name = Column(String, nullable=False)
     file_size_bytes = Column(BigInteger, nullable=False)
     uploaded_timestamp = Column(DateTime, nullable=False)
+    facet_group = Column(String, nullable=False)
     # NOTE: this column actually has type CITEXT.
     data_format = Column(String, nullable=False)
     additional_metadata = Column(JSONB, nullable=True)

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -867,6 +867,7 @@ class DownloadableFiles(CommonColumns):
         trial_id: str,
         upload_type: str,
         data_format: str,
+        facet_group: str,
         blob: Blob,
         session: Session,
         commit: bool = True,
@@ -890,6 +891,7 @@ class DownloadableFiles(CommonColumns):
         df.trial_id = trial_id
         df.upload_type = upload_type
         df.data_format = data_format
+        df.facet_group = facet_group
         df.object_url = blob.name
         df.file_name = blob.name
         df.file_size_bytes = blob.size

--- a/migrations/versions/7590a700f9bc_.py
+++ b/migrations/versions/7590a700f9bc_.py
@@ -1,0 +1,201 @@
+"""empty message
+
+Revision ID: 7590a700f9bc
+Revises: e2744508442a
+Create Date: 2020-08-19 10:38:55.003131
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from cidc_api.models import DownloadableFiles
+
+# revision identifiers, used by Alembic.
+revision = "7590a700f9bc"
+down_revision = "e2744508442a"
+branch_labels = None
+depends_on = None
+
+# NOTE: the below code is based on the contents of cidc_api/models/facets.py at commit hash 48f76f2.
+# It's duplicated here so that this migration does not depend on the `cidc_api.models.facets` module.
+
+assay_facets = {
+    "CyTOF": {
+        "Source": [
+            "%source_%.fcs",
+            "%spike_in_fcs.fcs",
+            "%normalized_and_debarcoded.fcs",
+            "%processed.fcs",
+        ],
+        "Cell Counts": [
+            "%cell_counts_assignment.csv",
+            "%cell_counts_compartment.csv",
+            "%cell_counts_profiling.csv",
+        ],
+        "Labeled Source": ["%source.fcs"],
+        "Analysis Results": ["%analysis.zip", "%results.zip"],
+        "Key": ["%/assignment.csv", "%/compartment.csv", "%/profiling.csv"],
+    },
+    "WES": {
+        "Source": ["%wes%reads_%.bam", "%wes%r1_%.fastq.gz", "%wes%r2_%.fastq.gz"],
+        "Germline": ["%vcfcompare.txt", "%optimalpurityvalue.txt"],
+        "Clonality": ["%clonality_pyclone.tsv"],
+        "Copy Number": ["%copynumber_cnvcalls.txt", "%copynumber_cnvcalls.txt.tn.tsv"],
+        "Neoantigen": [
+            "%MHC_Class_I_all_epitopes.tsv",
+            "%MHC_Class_I_filtered_condensed_ranked.tsv",
+            "%MHC_Class_II_all_epitopes.tsv",
+            "%MHC_Class_II_filtered_condensed_ranked.tsv",
+        ],
+        "Somatic": [
+            "%vcf_tnscope_output.vcf",
+            "%maf_tnscope_output.maf",
+            "%vcf_tnscope_filter.vcf",
+            "%maf_tnscope_filter.maf",
+            "%tnscope_exons_broad.gz",
+            "%tnscope_exons_mda.gz",
+            "%tnscope_exons_mocha.gz",
+        ],
+        "Alignment": [
+            "%tn_corealigned.bam",
+            "%tn_corealigned.bam.bai",
+            "%recalibrated.bam",
+            "%recalibrated.bam.bai",
+            "%sorted.dedup.bam",
+            "%sorted.dedup.bam.bai",
+        ],
+        "Metrics": [
+            "%all_sample_summaries.txt",
+            "%coverage_metrics.txt",
+            "%target_metrics.txt",
+            "%coverage_metrics_summary.txt",
+            "%target_metrics_summary.txt",
+            "%mosdepth_region_dist_broad.txt",
+            "%mosdepth_region_dist_mda.txt",
+            "%mosdepth_region_dist_mocha.txt",
+            "%optitype_result.tsv",
+        ],
+        "HLA Type": ["%optitype_result.tsv"],
+        "Report": ["%wes_version.txt"],
+    },
+    "RNA": {
+        "Source": ["%rna%reads_%.bam", "%rna%r1_%.fastq.gz", "%rna%r2_%.fastq.gz"],
+        "Alignment": [
+            "%sorted.bam",
+            "%sorted.bam.bai",
+            "%sorted.bam.stat.txt",
+            "%downsampling.bam",
+            "%downsampling.bam.bai",
+        ],
+        "Quality": [
+            "%downsampling_housekeeping.bam",
+            "%downsampling_housekeeping.bam.bai",
+            "%read_distrib.txt",
+            "%tin_score.txt",
+            "%tin_score.summary.txt",
+        ],
+        "Gene Quantification": [
+            "%quant.sf",
+            "%transcriptome.bam.log",
+            "%aux_info_ambig_info.tsv",
+            "%aux_info_expected_bias.gz",
+            "%aux_info_fld.gz",
+            "%aux_info_meta_info.json",
+            "%aux_info_observed_bias.gz",
+            "%aux_info_observed_bias_3p.gz",
+            "%cmd_info.json",
+            "%salmon_quant.log",
+        ],
+    },
+    "mIF": {
+        "Source Images": [
+            "%composite_image.tif",
+            "%component_data.tif",
+            "%multispectral.im3",
+        ],
+        "Analysis Images": ["%binary_seg_maps.tif", "%phenotype_map.tif"],
+        "Analysis Data": [
+            "%score_data_%.txt",
+            "%cell_seg_data.txt",
+            "%cell_seg_data_summary.txt",
+        ],
+    },
+    "Olink": {"All Olink Files": ["%/olink%"]},
+    "IHC": {"All IHC Files": ["%/ihc%"]},
+}
+
+clinical_facets = {
+    "Participants Info": ["%participants.csv"],
+    "Samples Info": ["%samples.csv"],
+}
+
+
+facets = {"Assay Type": assay_facets, "Clinical Type": clinical_facets}
+
+
+def list_facet_paths():
+    paths = []
+    for assay_name, subfacets in assay_facets.items():
+        for subfacet in subfacets.keys():
+            paths.append(["Assay Type", assay_name, subfacet])
+
+    for clinical_type in clinical_facets.keys():
+        paths.append(["Clinical Type", clinical_type])
+
+    return paths
+
+
+def get_facets_for_path(object_url_like, path):
+    try:
+        assert len(path) in (2, 3)
+        facet_config = facets
+        for key in path:
+            facet_config = facet_config[key]
+        assert isinstance(facet_config, list)
+    except Exception as e:
+        raise ValueError(f"no facet for path {path}")
+
+    clauses = [object_url_like(clause) for clause in facet_config]
+    return clauses
+
+
+def build_facet_group_for_existing_files():
+    """
+    Builds a sqlalchemy `case` statement for figuring out which 
+    facet group a particular record belongs to.
+
+    This will build facet groups like "Assay Type|mIF|Source Images"
+    """
+    cases = []
+    for path in list_facet_paths():
+        object_url_like = lambda exp: sa.text(f"object_url LIKE '{exp}'")
+        path_facets = sa.or_(*get_facets_for_path(object_url_like, path))
+        facet_group = "|".join(path)
+        cases.append((path_facets, facet_group))
+
+    return sa.case(cases)
+
+
+facet_group_cases = build_facet_group_for_existing_files()
+
+
+def upgrade():
+    op.add_column(
+        "downloadable_files", sa.Column("facet_group", sa.String(), nullable=True)
+    )
+
+    session = sa.orm.session.Session(bind=op.get_bind())
+    session.query(DownloadableFiles).update(
+        {"facet_group": facet_group_cases}, synchronize_session="fetch"
+    )
+    session.commit()
+
+    op.alter_column(
+        "downloadable_files", sa.Column("facet_group", sa.String(), nullable=False)
+    )
+
+
+def downgrade():
+    # ### commands auto generated by Alembic - please adjust! ###
+    op.drop_column("downloadable_files", "facet_group")
+    # ### end Alembic commands ###

--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -4,7 +4,7 @@ flask-sqlalchemy~=2.4.0
 marshmallow-sqlalchemy==0.22.3
 google-cloud-storage~=1.25.0
 google-cloud-pubsub==0.42.1
-cidc-schemas~=0.18.10
+cidc-schemas~=0.19.0
 python-dotenv==0.10.3
 requests==2.22.0
 # pin jinja version to resolve cidc-schemas dependency issue

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
     license="MIT license",
     packages=["cidc_api.config", "cidc_api.models", "cidc_api.shared"],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.18.27",
+    version="0.19.0",
     zip_safe=False,
 )

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -569,7 +569,7 @@ def test_create_downloadable_file_from_blob(clean_db, monkeypatch):
         )
     )
     df = DownloadableFiles.create_from_blob(
-        "id", "pbmc", "Shipping Manifest", fake_blob
+        "id", "pbmc", "Shipping Manifest", "pbmc/shipping", fake_blob
     )
 
     # Mock artifact upload publishing
@@ -589,7 +589,7 @@ def test_create_downloadable_file_from_blob(clean_db, monkeypatch):
     fake_blob.size = 6
     fake_blob.md5_hash = "6"
     df = DownloadableFiles.create_from_blob(
-        "id", "pbmc", "Shipping Manifest", fake_blob
+        "id", "pbmc", "Shipping Manifest", "pbmc/shipping", fake_blob
     )
 
     # Check that the file was created
@@ -603,7 +603,12 @@ def test_create_downloadable_file_from_blob(clean_db, monkeypatch):
 
     # Check that artifact upload publishes
     DownloadableFiles.create_from_blob(
-        "id", "pbmc", "Shipping Manifest", fake_blob, alert_artifact_upload=True
+        "id",
+        "pbmc",
+        "Shipping Manifest",
+        "pbmc/shipping",
+        fake_blob,
+        alert_artifact_upload=True,
     )
     publisher.assert_called_once_with(fake_blob.name)
 


### PR DESCRIPTION
Existing file records `facet_group` column is set to their facet path in the current facet configuration, e.g., `Assay Type|mIF|Source Images`.

This PR only adds this migration. Updates to the faceted search implementation will come in a later PR.