### PR TITLE
Provide default value in facet_group migration

### DIFF
--- a/migrations/versions/26ba8b4e9b51_consolidate_internal_facet_group.py
+++ b/migrations/versions/26ba8b4e9b51_consolidate_internal_facet_group.py
@@ -164,7 +164,10 @@ def build_facet_group_name_change():
         else:
             raise Exception("whoops! migration misconfigured")
 
-    return sa.case(cases)
+    # Some facet groups don't need to be renamed, so default to
+    # not changing a file's facet_group if the facet_group doesn't
+    # show up in the renaming map.
+    return sa.case(cases, else_=DownloadableFiles.facet_group)
 
 
 facet_group_updates = build_facet_group_name_change()


### PR DESCRIPTION
#298 accidentally `null`ified `facet_group` values that didn't need renaming.