### PR TITLE
Add endpoint for getting 'related' files 

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -28,7 +28,6 @@ from sqlalchemy import (
     select,
     literal_column,
     not_,
-    or_,
 )
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.hybrid import hybrid_property

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -27,6 +27,8 @@ from sqlalchemy import (
     case,
     select,
     literal_column,
+    not_,
+    or_,
 )
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -37,6 +39,7 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql import expression, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.engine import ResultProxy
 from sqlalchemy.engine.interfaces import ExecutionContext
 
 from cidc_schemas import prism, unprism, json_validation
@@ -951,15 +954,15 @@ class DownloadableFiles(CommonColumns):
         return DATA_CATEGORY_CASE_CLAUSE
 
     @hybrid_property
-    def consolidated_upload_type(self):
+    def data_category_prefix(self):
         """
         The overarching data category for a file. E.g., files with `upload_type` of
-        "cytof"` and `"cytof_analyis"` should both have a `consolidated_upload_type` of `"CyTOF"`.
+        "cytof"` and `"cytof_analyis"` should both have a `data_category_prefix` of `"CyTOF"`.
         """
         return self.data_category.split(FACET_NAME_DELIM, 1)[0]
 
-    @consolidated_upload_type.expression
-    def consolidated_upload_type(cls):
+    @data_category_prefix.expression
+    def data_category_prefix(cls):
         return func.split_part(DATA_CATEGORY_CASE_CLAUSE, FACET_NAME_DELIM, 1)
 
     @hybrid_property
@@ -969,6 +972,61 @@ class DownloadableFiles(CommonColumns):
     @file_purpose.expression
     def file_purpose(cls):
         return FILE_PURPOSE_CASE_CLAUSE
+
+    @property
+    def cimac_id(self):
+        """
+        Extract the `cimac_id` associated with this file, if any, by searching the file's 
+        additional metadata for a field with a key like `<some>.<path>.cimac_id`.
+
+        NOTE: this is not a sqlalchemy hybrid_property, and it can't be used directly in queries.
+        """
+        for key, value in self.additional_metadata.items():
+            if key.endswith("cimac_id"):
+                return value
+        return None
+
+    @with_default_session
+    def get_related_files(self, session: Session) -> list:
+        """
+        Return a list of file records related to this file. We could define "related"
+        in any number of ways, but currently, a related file:
+            * is sample-specific, and relates to the same sample as this file if this file 
+              has an associated `cimac_id`.
+            * isn't sample-specific, and relates to the same `data_category_prefix`.
+        """
+        if self.cimac_id is not None:
+            query = text(
+                "SELECT downloadable_files.* "
+                "FROM downloadable_files, LATERAL jsonb_each_text(additional_metadata) addm_kv "
+                "WHERE addm_kv.value LIKE :cimac_id AND trial_id = :trial_id AND id != :id"
+            )
+            params = {
+                "cimac_id": f"%{self.cimac_id}",
+                "trial_id": self.trial_id,
+                "id": self.id,
+            }
+            related_files = result_proxy_to_models(
+                session.execute(query, params), DownloadableFiles
+            )
+        else:
+            # If a file's additional metadata JSON has no key that ends with `.cimac_id`,
+            # then we consider that file "not sample specific".
+            not_sample_specific = not_(
+                literal_column("additional_metadata::text").like('%.cimac_id":%')
+            )
+            related_files = (
+                session.query(DownloadableFiles)
+                .filter(
+                    DownloadableFiles.trial_id == self.trial_id,
+                    DownloadableFiles.data_category_prefix == self.data_category_prefix,
+                    DownloadableFiles.id != self.id,
+                    not_sample_specific,
+                )
+                .all()
+            )
+
+        return related_files
 
     @staticmethod
     def build_file_filter(
@@ -1150,12 +1208,12 @@ class DownloadableFiles(CommonColumns):
             select(
                 [
                     cls.trial_id,
-                    cls.consolidated_upload_type.label(type_col.key),
+                    cls.data_category_prefix.label(type_col.key),
                     cls.file_purpose.label(purp_col.key),
                     func.json_agg(cls.id).label(ids_col.key),
                 ]
             )
-            .group_by(cls.trial_id, cls.consolidated_upload_type, cls.file_purpose)
+            .group_by(cls.trial_id, cls.data_category_prefix, cls.file_purpose)
             .alias("id_bundles")
         )
         purpose_bundles = (
@@ -1202,3 +1260,15 @@ FILE_PURPOSE_CASE_CLAUSE = case(
         for facet_group, file_details in details_dict.items()
     ]
 )
+
+
+def result_proxy_to_models(
+    result_proxy: ResultProxy, model: BaseModel
+) -> List[BaseModel]:
+    model_instances = []
+    for row_proxy in result_proxy:
+        row_dict = {}
+        for key, value in row_proxy.items():
+            row_dict[key] = value
+        model_instances.append(model(**row_dict))
+    return model_instances

--- a/cidc_api/models/schemas.py
+++ b/cidc_api/models/schemas.py
@@ -70,6 +70,7 @@ class DownloadableFileSchema(BaseSchema):
 
     file_ext = fields.Str(dump_only=True)
     data_category = fields.Str(dump_only=True)
+    data_category_prefix = fields.Str(dump_only=True)
 
 
 DownloadableFileListSchema = _make_list_schema(DownloadableFileSchema())

--- a/cidc_api/models/schemas.py
+++ b/cidc_api/models/schemas.py
@@ -71,6 +71,7 @@ class DownloadableFileSchema(BaseSchema):
     file_ext = fields.Str(dump_only=True)
     data_category = fields.Str(dump_only=True)
     data_category_prefix = fields.Str(dump_only=True)
+    cimac_id = fields.Str(dump_only=True)
 
 
 DownloadableFileListSchema = _make_list_schema(DownloadableFileSchema())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -414,6 +414,7 @@ def test_endpoint_urls(cidc_api):
         "/downloadable_files/download_url",
         "/downloadable_files/filter_facets",
         "/downloadable_files/<int:downloadable_file>",
+        "/downloadable_files/<int:downloadable_file>/related_files",
         "/info/assays",
         "/info/analyses",
         "/info/manifests",


### PR DESCRIPTION
Use a file's `additional_metadata` and `data_category` values to determine a list of files that are meaningfully related to that file.

PR is a draft because I need to more thoroughly test the `DownloadableFiles.get_related_files` method.