### PR TITLE
`DownloadableFiles.data_category_prefix` doesn't handle `data_category == None`

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -958,6 +958,8 @@ class DownloadableFiles(CommonColumns):
         The overarching data category for a file. E.g., files with `upload_type` of
         "cytof"` and `"cytof_analyis"` should both have a `data_category_prefix` of `"CyTOF"`.
         """
+        if self.data_category is None:
+            return None
         return self.data_category.split(FACET_NAME_DELIM, 1)[0]
 
     @data_category_prefix.expression

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -624,6 +624,15 @@ def test_create_downloadable_file_from_blob(clean_db, monkeypatch):
     publisher.assert_called_once_with(fake_blob.name)
 
 
+def test_downloadable_files_data_category_prefix():
+    """Check that data_category_prefix's are derived as expected"""
+    file_w_category = DownloadableFiles(facet_group="/wes/r1_.fastq.gz")
+    assert file_w_category.data_category_prefix == "WES"
+
+    file_no_category = DownloadableFiles()
+    assert file_no_category.data_category_prefix == None
+
+
 @db_test
 def test_downloadable_files_get_related_files(clean_db):
     # Create a trial to avoid constraint errors


### PR DESCRIPTION
Quick fix for a bug related to #309