### PR TITLE
Added logging for writing/deleting to the permissions table

### DIFF
--- a/cidc_api/resources/permissions.py
+++ b/cidc_api/resources/permissions.py
@@ -82,8 +82,9 @@ def get_permission(permission: Permissions) -> Permissions:
 @marshal_response(permission_schema, 201)
 def create_permission(permission: Permissions) -> Permissions:
     """Create a new permission record."""
-    granter = get_current_user()
-    permission.granted_by_user = granter.id
+    if permission.granted_by_user is None:
+        granter = get_current_user()
+        permission.granted_by_user = granter.id
     try:
         permission.insert()
     except IntegrityError as e:

--- a/cidc_api/resources/permissions.py
+++ b/cidc_api/resources/permissions.py
@@ -101,7 +101,8 @@ def create_permission(permission: Permissions) -> Permissions:
 def delete_permission(permission: Permissions):
     """Delete a permission record."""
     try:
-        permission.delete()
+        deleter = get_current_user()
+        permission.delete(deleted_by=deleter)
     except NoResultFound as e:
         raise NotFound(str(e.orig))
     except IAMException as e:

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -682,7 +682,7 @@ def test_permissions_delete(clean_db, monkeypatch):
 
     # Deletion of an existing permission leads to no error
     gcloud_client.reset_mocks()
-    perm.delete(deleted_by=user)
+    perm.delete(deleted_by=user.id)
     gcloud_client.revoke_download_access.assert_called_once()
     gcloud_client.grant_download_access.assert_not_called()
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -738,6 +738,11 @@ def test_permissions_delete(clean_db, monkeypatch, capsys):
     with capsys.disabled():
         perm.insert()
 
+    # Deleting a record by a user doesn't exist leads to an error
+    gcloud_client.reset_mocks()
+    with pytest.raises(NoResultFound, match="no user with id"):
+        perm.delete(deleted_by=999999)
+
     # Deletion of an existing permission leads to no error
     gcloud_client.reset_mocks()
     perm.delete(deleted_by=user.id)

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from cidc_api.app import app
 from cidc_api.models import (
+    CommonColumns,
     Users,
     TrialMetadata,
     UploadJobs,
@@ -662,29 +663,91 @@ def test_assay_upload_status():
 
 
 @db_test
-def test_permissions_delete(clean_db, monkeypatch):
+def test_permissions_insert(clean_db, monkeypatch, capsys):
+    gcloud_client = mock_gcloud_client(monkeypatch)
+    user = Users(email="test@user.com")
+    user.insert()
+    trial = TrialMetadata(trial_id=TRIAL_ID, metadata_json=METADATA)
+    trial.insert()
+
+    _insert = MagicMock()
+    monkeypatch.setattr(CommonColumns, "insert", _insert)
+
+    # if don't give granted_by_user
+    perm = Permissions(
+        granted_to_user=user.id, trial_id=trial.trial_id, upload_type="wes"
+    )
+    with pytest.raises(IntegrityError, match="`granted_by_user` user must be given"):
+        perm.insert()
+    _insert.assert_not_called()
+
+    # if give bad granted_by_user
+    _insert.reset_mock()
+    perm = Permissions(
+        granted_to_user=user.id,
+        trial_id=trial.trial_id,
+        upload_type="wes",
+        granted_by_user=999999,
+    )
+    with pytest.raises(IntegrityError, match="`granted_by_user` user must exist"):
+        perm.insert()
+    _insert.assert_not_called()
+
+    # if give bad granted_to_user
+    _insert.reset_mock()
+    perm = Permissions(
+        granted_to_user=999999,
+        trial_id=trial.trial_id,
+        upload_type="wes",
+        granted_by_user=user.id,
+    )
+    with pytest.raises(IntegrityError, match="`granted_to_user` user must exist"):
+        perm.insert()
+    _insert.assert_not_called()
+
+    # This one will work
+    _insert.reset_mock()
+    perm = Permissions(
+        granted_to_user=user.id,
+        trial_id=trial.trial_id,
+        upload_type="wes",
+        granted_by_user=user.id,
+    )
+    perm.insert()
+    _insert.assert_called_once()
+    captured = capsys.readouterr()
+    assert (
+        captured.out.strip()
+        == f"admin-action: {user.email} gave {user.email} the permission wes on {trial.trial_id}"
+    )
+
+
+@db_test
+def test_permissions_delete(clean_db, monkeypatch, capsys):
     gcloud_client = mock_gcloud_client(monkeypatch)
     user = Users(email="test@user.com")
     user.insert()
     trial = TrialMetadata(trial_id=TRIAL_ID, metadata_json=METADATA)
     trial.insert()
     perm = Permissions(
-        granted_to_user=user.id, trial_id=trial.trial_id, upload_type="wes"
+        granted_to_user=user.id,
+        trial_id=trial.trial_id,
+        upload_type="wes",
+        granted_by_user=user.id,
     )
-    perm.insert()
-
-    # Failing to provide a deleted_by user throws ValueError
-    gcloud_client.reset_mocks()
-    with pytest.raises(ValueError, match="must provide a deleted_by"):
-        perm.delete()
-    gcloud_client.revoke_download_access.assert_not_called()
-    gcloud_client.grant_download_access.assert_not_called()
+    with capsys.disabled():
+        perm.insert()
 
     # Deletion of an existing permission leads to no error
     gcloud_client.reset_mocks()
     perm.delete(deleted_by=user.id)
     gcloud_client.revoke_download_access.assert_called_once()
     gcloud_client.grant_download_access.assert_not_called()
+    captured = capsys.readouterr()
+    assert (
+        captured.out.strip()
+        == f"admin-action: {user.email} removed from {user.email} the permission wes on {trial.trial_id}"
+    )
 
     # Deleting an already-deleted record is idempotent
     gcloud_client.reset_mocks()
@@ -715,7 +778,10 @@ def test_permissions_grant_all_iam_permissions(clean_db, monkeypatch):
     upload_types = ["wes", "cytof", "rna", "plasma"]
     for upload_type in upload_types:
         Permissions(
-            granted_to_user=user.id, trial_id=trial.trial_id, upload_type=upload_type
+            granted_to_user=user.id,
+            trial_id=trial.trial_id,
+            upload_type=upload_type,
+            granted_by_user=user.id,
         ).insert()
 
     Permissions.grant_all_iam_permissions()
@@ -746,7 +812,10 @@ def test_permissions_revoke_all_iam_permissions(clean_db, monkeypatch):
     upload_types = ["wes", "cytof", "rna", "plasma"]
     for upload_type in upload_types:
         Permissions(
-            granted_to_user=user.id, trial_id=trial.trial_id, upload_type=upload_type
+            granted_to_user=user.id,
+            trial_id=trial.trial_id,
+            upload_type=upload_type,
+            granted_by_user=user.id,
         ).insert()
 
     Permissions.revoke_all_iam_permissions()

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -204,7 +204,10 @@ def test_get_related_files(cidc_api, clean_db, monkeypatch):
     # Give the user one permission
     with cidc_api.app_context():
         perm = Permissions(
-            granted_to_user=user_id, trial_id=trial_id, upload_type=upload_types[0]
+            granted_to_user=user_id,
+            trial_id=trial_id,
+            upload_type=upload_types[0],
+            granted_by_user=user_id,
         )
         perm.insert()
 

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -88,7 +88,10 @@ def test_list_downloadable_files(cidc_api, clean_db, monkeypatch):
     # Give the user one permission
     with cidc_api.app_context():
         perm = Permissions(
-            granted_to_user=user_id, trial_id=trial_id, upload_type=upload_types[0]
+            granted_to_user=user_id,
+            trial_id=trial_id,
+            upload_type=upload_types[0],
+            granted_by_user=user_id,
         )
         perm.insert()
 
@@ -151,7 +154,10 @@ def test_get_downloadable_file(cidc_api, clean_db, monkeypatch):
     # Give the user one permission
     with cidc_api.app_context():
         perm = Permissions(
-            granted_to_user=user_id, trial_id=trial_id, upload_type=upload_types[0]
+            granted_to_user=user_id,
+            trial_id=trial_id,
+            upload_type=upload_types[0],
+            granted_by_user=user_id,
         )
         perm.insert()
 
@@ -191,7 +197,10 @@ def test_get_filelist(cidc_api, clean_db, monkeypatch):
     # Give the user one permission
     with cidc_api.app_context():
         perm = Permissions(
-            granted_to_user=user_id, trial_id=trial_id, upload_type=upload_types[0]
+            granted_to_user=user_id,
+            trial_id=trial_id,
+            upload_type=upload_types[0],
+            granted_by_user=user_id,
         )
         perm.insert()
 
@@ -271,7 +280,10 @@ def test_get_download_url(cidc_api, clean_db, monkeypatch):
 
     with cidc_api.app_context():
         perm = Permissions(
-            granted_to_user=user_id, trial_id=trial_id, upload_type=upload_types[0]
+            granted_to_user=user_id,
+            trial_id=trial_id,
+            upload_type=upload_types[0],
+            granted_by_user=user_id,
         )
         perm.insert()
 

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -42,10 +42,16 @@ def setup_trial_metadata(cidc_api, user_id=None) -> Tuple[int, int]:
         trial.insert()
         if grant_perm and user_id:
             Permissions(
-                granted_to_user=user_id, trial_id=trial.trial_id, upload_type="wes"
+                granted_to_user=user_id,
+                trial_id=trial.trial_id,
+                upload_type="wes",
+                granted_by_user=user_id,
             ).insert()
             Permissions(
-                granted_to_user=user_id, trial_id=trial.trial_id, upload_type="cytof"
+                granted_to_user=user_id,
+                trial_id=trial.trial_id,
+                upload_type="cytof",
+                granted_by_user=user_id,
             ).insert()
         return trial.id
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -114,6 +114,7 @@ permissions = {
     "json": {
         "id": TEST_RECORD_ID,
         "granted_to_user": TEST_RECORD_ID,
+        "granted_by_user": TEST_RECORD_ID,
         "trial_id": trial_metadata["json"]["trial_id"],
         "upload_type": downloadable_files["json"]["upload_type"],
     },


### PR DESCRIPTION
new deleted_by param on Permissions.delete
throw error if no deleted_by given
update tests to check for error if don't give delete_by
update api calls to provide deleted_by