### PR TITLE
More robust default value behavior for additional metadata

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -1019,6 +1019,10 @@ class DownloadableFiles(CommonColumns):
                 return value
         return None
 
+    @validates("additional_metadata")
+    def check_additional_metadata_default(self, key, value):
+        return {} if value in ["null", None, {}] else value
+
     @with_default_session
     def get_related_files(self, session: Session) -> list:
         """
@@ -1116,9 +1120,11 @@ class DownloadableFiles(CommonColumns):
 
         # Filter out keys that aren't columns
         supported_columns = DownloadableFiles.__table__.columns.keys()
-        filtered_metadata = {"trial_id": trial_id, "upload_type": upload_type}
-        if additional_metadata not in ("null", None, {}):
-            filtered_metadata["additional_metadata"] = additional_metadata
+        filtered_metadata = {
+            "trial_id": trial_id,
+            "upload_type": upload_type,
+            "additional_metadata": additional_metadata,
+        }
 
         for key, value in file_metadata.items():
             if key in supported_columns:

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,13 @@ setup(
     python_requires=">=3.6",
     install_requires=requirements,
     license="MIT license",
-    packages=["cidc_api.config", "cidc_api.models", "cidc_api.shared", "cidc_api.models.files"],
+    packages=[
+        "cidc_api.config",
+        "cidc_api.models",
+        "cidc_api.shared",
+        "cidc_api.models.files",
+    ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.20.5",
+    version="0.20.6",
     zip_safe=False,
 )

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -560,6 +560,36 @@ def test_create_downloadable_file_from_metadata(clean_db, monkeypatch):
 
 
 @db_test
+def test_downloadable_files_additional_metadata_default(clean_db):
+    TrialMetadata.create(TRIAL_ID, METADATA)
+    df = DownloadableFiles(
+        trial_id=TRIAL_ID,
+        upload_type="wes",
+        object_url="10021/Patient 1/sample 1/aliquot 1/wes_forward.fastq",
+        file_name="wes_forward.fastq",
+        file_size_bytes=1,
+        md5_hash="hash1234",
+        uploaded_timestamp=datetime.now(),
+        data_format="FASTQ",
+    )
+
+    # Check no value passed
+    df.insert()
+    assert df.additional_metadata == {}
+
+    for nullish_value in [None, "null", {}]:
+        df.additional_metadata = nullish_value
+        df.update()
+        assert df.additional_metadata == {}
+
+    # Non-nullish value doesn't get overridden
+    non_nullish_value = {"foo": "bar"}
+    df.additional_metadata = non_nullish_value
+    df.update()
+    assert df.additional_metadata == non_nullish_value
+
+
+@db_test
 def test_create_downloadable_file_from_blob(clean_db, monkeypatch):
     """Try to create a downloadable file from a GCS blob"""
     fake_blob = MagicMock()


### PR DESCRIPTION
Previously, only `DownloadableFiles.create_from_metadata` was checking for null-ish `additional_metadata` values, which meant that it was still possible to set `additional_metadata` to `"null"` (JSON null, not SQL null) via, e.g., `DownloadableFiles.create_from_blob`.

This lead to derivative files getting created with null `additional_metadata` here: https://github.com/CIMAC-CIDC/cidc-cloud-functions/blob/d9339a301c6d473bbf7331cb07c1d3458a2ac598/functions/upload_postprocessing.py#L99

This PR adds a sqlalchemy validator on the `DownloadableFiles.additional_metadata` attribute that encodes appropriate defaulting behavior for all `__setattr__` operations on that attribute.