### PR TITLE
Add back code for sending email notification to newly-approved users

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ AUTH0_CLIENT_ID='Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD'
 PRISM_ENCRYPT_KEY='key'
 
 ENV='dev'
-DEBUG=True
+DEBUG=False
 TEST_POSTGRES_URI = 'postgresql://cidcdev:1234@localhost:5432/cidctest'
 
 # Uncomment to use local cloud functions

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -65,6 +65,7 @@ from ..shared.gcloud_client import (
     publish_upload_success,
     grant_download_access,
     revoke_download_access,
+    send_email,
 )
 
 
@@ -251,6 +252,14 @@ class Users(CommonColumns):
     approval_date = Column(DateTime)
     role = Column(Enum(*ROLES, name="role"))
     disabled = Column(Boolean, default=False, server_default="false")
+
+    @validates("approval_date")
+    def send_approval_confirmation(self, key, new_approval_date):
+        """Send this user an approval email if their account has just been approved"""
+        if self.approval_date is None and new_approval_date is not None:
+            emails.confirm_account_approval(self, send_email=True)
+
+        return new_approval_date
 
     def is_admin(self) -> bool:
         """Returns true if this user is a CIDC admin."""

--- a/cidc_api/shared/emails.py
+++ b/cidc_api/shared/emails.py
@@ -34,12 +34,13 @@ def confirm_account_approval(user) -> dict:
     subject = "CIDC Account Approval"
 
     html_content = f"""
-    <p>Hello {user.first_n} {user.last_n},</p>
+    <p>Hello {user.first_n},</p>
     <p>
-        Your registration for the CIMAC-CIDC Portal is now approved. 
-        To continue to the Portal, visit https://portal.cimac-network.org.
+        Your CIMAC-CIDC Portal account has been approved! 
+        To begin browsing and downloading data, visit https://portal.cimac-network.org.
     </p>
-    <p>If you haven't already, please reach out to cidc@jimmy.harvard.edu to request access to data for particular trials and assays.</p>
+    <p>
+        <strong>Note:</strong> If you haven't already, please email cidc@jimmy.harvard.edu to request permission to view data for the trials and assays relevant to your work.</p>
     <p>Thanks,<br/>The CIDC Project Team</p>
     """
 

--- a/cidc_api/shared/emails.py
+++ b/cidc_api/shared/emails.py
@@ -31,15 +31,15 @@ def sendable(email_template):
 def confirm_account_approval(user) -> dict:
     """Send a message to the user confirming that they are approved to use the CIDC."""
 
-    subject = "CIDC Registration Approval"
+    subject = "CIDC Account Approval"
 
     html_content = f"""
     <p>Hello {user.first_n} {user.last_n},</p>
     <p>
-        Your registration for the CIMAC-CIDC Data Portal has now been approved. 
+        Your registration for the CIMAC-CIDC Portal is now approved. 
         To continue to the Portal, visit https://portal.cimac-network.org.
     </p>
-    <p>If you have any questions, please email us at cidc@jimmy.harvard.edu.</p>
+    <p>If you haven't already, please reach out to cidc@jimmy.harvard.edu to request access to data for particular trials and assays.</p>
     <p>Thanks,<br/>The CIDC Project Team</p>
     """
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -956,17 +956,18 @@ def test_permissions_revoke_all_iam_permissions(clean_db, monkeypatch):
 @db_test
 def test_user_confirm_approval(clean_db, monkeypatch):
     """Ensure that users are notified when their account goes from pending to approved."""
-    gcloud_client = mock_gcloud_client(monkeypatch)
+    confirm_account_approval = MagicMock()
+    monkeypatch.setattr(
+        "cidc_api.shared.emails.confirm_account_approval", confirm_account_approval
+    )
 
     user = Users(email="test@user.com")
     user.insert()
 
     # The confirmation email shouldn't be sent for updates unrelated to account approval
     user.update(changes={"first_n": "foo"})
-    gcloud_client.confirm_account_approval.assert_not_called()
+    confirm_account_approval.assert_not_called()
 
     # The confirmation email should be sent for updates related to account approval
-    user.update(changes={"role": "cimac-user"})
-    gcloud_client.confirm_account_approval.assert_called_once_with(
-        user, send_email=True
-    )
+    user.update(changes={"approval_date": datetime.now()})
+    confirm_account_approval.assert_called_once_with(user, send_email=True)

--- a/tests/shared/test_emails.py
+++ b/tests/shared/test_emails.py
@@ -24,7 +24,7 @@ def test_confirm_account_approval():
     assert user.first_n in email["html_content"]
     assert email["to_emails"] == [user.email]
     assert "Approval" in email["subject"]
-    assert "has now been approved" in email["html_content"]
+    assert "is now approved" in email["html_content"]
 
 
 def test_new_upload_alert(monkeypatch):

--- a/tests/shared/test_emails.py
+++ b/tests/shared/test_emails.py
@@ -24,7 +24,7 @@ def test_confirm_account_approval():
     assert user.first_n in email["html_content"]
     assert email["to_emails"] == [user.email]
     assert "Approval" in email["subject"]
-    assert "is now approved" in email["html_content"]
+    assert "has been approved" in email["html_content"]
 
 
 def test_new_upload_alert(monkeypatch):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,6 +32,7 @@ def mock_gcloud_client(monkeypatch) -> MagicMock:
     NOTE: only mocks usages of these methods within the `cidc_api.models.models` module.
     """
     gcloud_client = MagicMock()
+    gcloud_client.confirm_account_approval = MagicMock()
     gcloud_client.revoke_download_access = MagicMock()
     gcloud_client.grant_download_access = MagicMock()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,7 +32,6 @@ def mock_gcloud_client(monkeypatch) -> MagicMock:
     NOTE: only mocks usages of these methods within the `cidc_api.models.models` module.
     """
     gcloud_client = MagicMock()
-    gcloud_client.confirm_account_approval = MagicMock()
     gcloud_client.revoke_download_access = MagicMock()
     gcloud_client.grant_download_access = MagicMock()
 


### PR DESCRIPTION
I think I accidentally deleted this functionality during #245's major refactor. A cautionary tale about having good test coverage before refactoring code!