### PR TITLE
Logging improvements

### DIFF
--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -11,6 +11,7 @@ from cidc_schemas.template import generate_all_templates
 from .config.db import init_db
 from .config.settings import SETTINGS
 from .config.logging import get_logger
+from .shared.auth import validate_api_auth
 from .resources import register_resources
 
 logger = get_logger(__name__)

--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -32,8 +32,6 @@ init_db(app)
 register_resources(app)
 
 # Check that its auth configuration is validate
-from .shared.auth import validate_api_auth
-
 validate_api_auth(app)
 
 
@@ -49,7 +47,7 @@ def handle_errors(e: Exception):
             _error["message"] = e.description
 
         # general HTTP error log
-        logger.info(f"HTTP {status_code}: {_error['message']}")
+        logger.error(f"HTTP {status_code}: {_error['message']}")
     else:
         status_code = 500
         # This is an internal server error, so log the traceback for debugging purposes.

--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -10,15 +10,13 @@ from cidc_schemas.template import generate_all_templates
 
 from .config.db import init_db
 from .config.settings import SETTINGS
-from .config.logging import init_logger, logger
-from .shared.auth import validate_api_auth
+from .config.logging import get_logger
 from .resources import register_resources
+
+logger = get_logger(__name__)
 
 app = Flask(__name__, static_folder=None)
 app.config.update(SETTINGS)
-
-# Set up logging
-init_logger(app)
 
 # Enable CORS
 CORS(app, resources={r"*": {"origins": app.config["ALLOWED_CLIENT_URL"]}})
@@ -33,6 +31,8 @@ init_db(app)
 register_resources(app)
 
 # Check that its auth configuration is validate
+from .shared.auth import validate_api_auth
+
 validate_api_auth(app)
 
 
@@ -48,7 +48,7 @@ def handle_errors(e: Exception):
             _error["message"] = e.description
 
         # general HTTP error log
-        logger().info(f"HTTP {status_code}: {_error['message']}")
+        logger.info(f"HTTP {status_code}: {_error['message']}")
     else:
         status_code = 500
         # This is an internal server error, so log the traceback for debugging purposes.

--- a/cidc_api/config/db.py
+++ b/cidc_api/config/db.py
@@ -19,8 +19,8 @@ def init_db(app: Flask):
     db.init_app(app)
     db.Model = BaseModel
     Migrate(app, db, app.config["MIGRATIONS_PATH"])
-    with app.app_context():
-        upgrade(app.config["MIGRATIONS_PATH"])
+    # with app.app_context():
+    #     upgrade(app.config["MIGRATIONS_PATH"])
 
 
 def get_sqlalchemy_database_uri(testing: bool = False) -> str:

--- a/cidc_api/config/db.py
+++ b/cidc_api/config/db.py
@@ -19,8 +19,8 @@ def init_db(app: Flask):
     db.init_app(app)
     db.Model = BaseModel
     Migrate(app, db, app.config["MIGRATIONS_PATH"])
-    # with app.app_context():
-    #     upgrade(app.config["MIGRATIONS_PATH"])
+    with app.app_context():
+        upgrade(app.config["MIGRATIONS_PATH"])
 
 
 def get_sqlalchemy_database_uri(testing: bool = False) -> str:

--- a/cidc_api/config/logging.py
+++ b/cidc_api/config/logging.py
@@ -1,17 +1,29 @@
+import sys
 import logging
 from typing import Optional
 
 from .settings import IS_GUNICORN, ENV
 
+# TODO: consider adding custom formatting that automatically adds request context
+# to all logs, like who the requesting user is and what URL they're accessing, e.g.
+
 
 def get_logger(name: Optional[str]) -> logging.Logger:
     """Get a configured logger with the given `name`."""
-    # If the app is running in gunicorn, connect to gunicorn's loggers
+    # If the app is running in gunicorn, inherit all config from gunicorn's loggers.
+    # Otherwise, configure a logger with reasonable defaults.
     logger = logging.getLogger(name)
     if IS_GUNICORN:
         gunicorn_logger = logging.getLogger("gunicorn.error")
         logger.handlers = gunicorn_logger.handlers
         logger.setLevel(gunicorn_logger.level)
     else:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(
+            logging.Formatter(
+                "[%(asctime)s] [%(threadName)s] [%(levelname)s]: %(message)s"
+            )
+        )
+        logger.addHandler(handler)
         logger.setLevel(logging.DEBUG if ENV == "dev" else logging.INFO)
     return logger

--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -26,6 +26,7 @@ DEBUG = environ.get("DEBUG") == "True"
 assert ENV == "dev" if DEBUG else True, "DEBUG mode is only allowed when ENV='dev'"
 TESTING = environ.get("TESTING") == "True"
 ALLOWED_CLIENT_URL = environ.get("ALLOWED_CLIENT_URL")
+IS_GUNICORN = "gunicorn" in environ.get("SERVER_SOFTWARE", "")
 
 ### Configure miscellaneous constants ###
 TEMPLATES_DIR = path.join("/tmp", "templates")

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -51,7 +51,7 @@ from .files import (
     FilePurpose,
     FACET_NAME_DELIM,
 )
-from ..config.logging import logger
+
 from ..config.db import BaseModel
 from ..config.settings import (
     PAGINATION_PAGE_SIZE,
@@ -68,6 +68,9 @@ from ..shared.gcloud_client import (
     revoke_download_access,
     send_email,
 )
+from ..config.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def with_default_session(f):
@@ -304,7 +307,7 @@ class Users(CommonColumns):
 
         user = Users.find_by_email(email)
         if not user:
-            logger().info(f"Creating new user with email {email}")
+            logger.info(f"Creating new user with email {email}")
             user = Users(email=email)
             user.insert(session=session)
         return user
@@ -408,7 +411,7 @@ class Permissions(CommonColumns):
                 orig=f"{grantee.email} has greater than or equal to the maximum number of allowed granular permissions ({GOOGLE_MAX_DOWNLOAD_PERMISSIONS}). Remove unused permissions to add others.",
             )
 
-        logger().info(
+        logger.info(
             f"admin-action: {grantor.email} gave {grantee.email} the permission {self.upload_type} on {self.trial_id}"
         )
 
@@ -452,7 +455,7 @@ class Permissions(CommonColumns):
                 "IAM revoke failed, and permission db record not removed."
             ) from e
 
-        logger().info(
+        logger.info(
             f"admin-action: {deleted_by_user.email} removed from {grantee.email} the permission {self.upload_type} on {self.trial_id}"
         )
         super().delete(session=session, commit=True)
@@ -624,7 +627,7 @@ class TrialMetadata(CommonColumns):
         Create a new clinical trial metadata record.
         """
 
-        logger().info(f"Creating new trial metadata with id {trial_id}")
+        logger.info(f"Creating new trial metadata with id {trial_id}")
         trial = TrialMetadata(trial_id=trial_id, metadata_json=metadata_json)
         trial.insert(session=session, commit=commit)
 
@@ -919,10 +922,10 @@ class UploadJobs(CommonColumns):
         if job is None or job.status == UploadJobStatus.MERGE_COMPLETED:
             raise ValueError(f"Upload job {job_id} doesn't exist or is already merged")
 
-        logger().info(f"About to merge extra md to {job.id}/{job.status}")
+        logger.info(f"About to merge extra md to {job.id}/{job.status}")
 
         for uuid, file in files.items():
-            logger().info(f"About to parse/merge extra md on {uuid}")
+            logger.info(f"About to parse/merge extra md on {uuid}")
             (
                 job.metadata_patch,
                 updated_artifact,
@@ -930,14 +933,14 @@ class UploadJobs(CommonColumns):
             ) = prism.merge_artifact_extra_metadata(
                 job.metadata_patch, uuid, job.upload_type, file
             )
-            logger().info(f"Updated md for {uuid}: {updated_artifact.keys()}")
+            logger.info(f"Updated md for {uuid}: {updated_artifact.keys()}")
 
         # A workaround fix for JSON field modifications not being tracked
         # by SQLalchemy for some reason. Using MutableDict.as_mutable(JSON)
         # in the model doesn't seem to help.
         flag_modified(job, "metadata_patch")
 
-        logger().info(f"Updated {job.id}/{job.status} patch: {job.metadata_patch}")
+        logger.info(f"Updated {job.id}/{job.status} patch: {job.metadata_patch}")
         session.commit()
 
     @classmethod

--- a/cidc_api/resources/upload_jobs.py
+++ b/cidc_api/resources/upload_jobs.py
@@ -231,7 +231,7 @@ def validate(template, xlsx):
         logger.info(f"validate passed")
         return jsonify(json)
     else:
-        logger.info(f"{len(error_list)} validation errors: [{error_list[0]!r}, ...]")
+        logger.error(f"{len(error_list)} validation errors: [{error_list[0]!r}, ...]")
         # The spreadsheet is invalid
         json["errors"] = error_list
         return jsonify(json)
@@ -252,7 +252,7 @@ def check_permissions(user, trial_id, template_type):
     if user.is_nci_user() and template_type in prism.SUPPORTED_MANIFESTS:
         return
     if not perm:
-        logger.info(
+        logger.error(
             f"Unauthorized attempt to access trial {trial_id} by {user.email!r}"
         )
         raise Unauthorized(
@@ -341,8 +341,7 @@ def upload_handler(allowed_types: List[str]):
             except prism.InvalidMergeTargetException as e:
                 # we have an invalid MD stored in db - users can't do anything about it.
                 # So we log it
-                logger.info(f"Internal error with trial {trial_id!r}", file=sys.stderr)
-                logger.info(e, file=sys.stderr)
+                logger.error(f"Internal error with trial {trial_id!r}\n{e}")
                 # and return an error. Though it's not BadRequest but rather an
                 # Internal Server error we report it like that, so it will be displayed
                 raise BadRequest(

--- a/cidc_api/resources/upload_jobs.py
+++ b/cidc_api/resources/upload_jobs.py
@@ -261,6 +261,11 @@ def check_permissions(user, trial_id, template_type):
         )
 
 
+def log_multiple_errors(errors: list):
+    if errors != []:
+        logger.error("\n".join(errors))
+
+
 def upload_handler(allowed_types: List[str]):
     """
     Extracts and validates the xlsx file from the request form body,
@@ -283,23 +288,20 @@ def upload_handler(allowed_types: List[str]):
 
             xlsx, errors = XlTemplateReader.from_excel(xlsx_file)
             logger.info(f"xlsx parsed: {len(errors)} errors")
-            for e in errors:
-                logger.info(f"\t{e}")
+            log_multiple_errors(errors)
             errors_so_far.extend(errors)
 
             # Run basic validations on the provided Excel file
             validations = validate(template, xlsx)
             logger.info(f"xlsx validated: {len(validations.json['errors'])} errors")
-            for e in validations.json["errors"]:
-                logger.info(f"\t{e}")
+            log_multiple_errors(validations.json["errors"])
             errors_so_far.extend(validations.json["errors"])
 
             md_patch, file_infos, errors = prism.prismify(xlsx, template)
             logger.info(
                 f"prismified: {len(errors)} errors, {len(file_infos)} file_infos"
             )
-            for e in errors:
-                logger.info(f"\t{e}")
+            log_multiple_errors(errors)
             errors_so_far.extend(errors)
 
             try:
@@ -347,8 +349,7 @@ def upload_handler(allowed_types: List[str]):
                     f"Internal error with {trial_id!r}. Please contact a CIDC Administrator."
                 ) from e
             logger.info(f"merged: {len(errors)} errors")
-            for e in errors:
-                logger.info(f"\t{e}")
+            log_multiple_errors(errors)
             errors_so_far.extend(errors)
 
             if errors_so_far:

--- a/cidc_api/resources/upload_jobs.py
+++ b/cidc_api/resources/upload_jobs.py
@@ -11,6 +11,7 @@ from jsonschema.exceptions import ValidationError
 from sqlalchemy.orm.session import Session
 from werkzeug.exceptions import BadRequest, NotFound, Unauthorized, PreconditionRequired
 
+from flask import current_app
 from cidc_schemas import prism, json_validation
 from cidc_schemas.template import Template
 from cidc_schemas.template_reader import XlTemplateReader
@@ -24,7 +25,6 @@ from ..shared.rest_utils import (
     unmarshal_request,
     use_args_with_pagination,
 )
-from ..config.logging import logger
 from ..config.settings import GOOGLE_UPLOAD_BUCKET, PRISM_ENCRYPT_KEY
 from ..models import (
     UploadJobs,
@@ -37,6 +37,9 @@ from ..models import (
     CIDCRole,
     Users,
 )
+from ..config.logging import get_logger
+
+logger = get_logger(__name__)
 
 prism.set_prism_encrypt_key(PRISM_ENCRYPT_KEY)
 
@@ -220,15 +223,15 @@ def validate(template, xlsx):
 
     TODO: add this endpoint to the OpenAPI docs
     """
-    logger().info(f"validate started")
+    logger.info(f"validate started")
     # Validate the .xlsx file with respect to the schema
     error_list = list(xlsx.iter_errors(template))
     json = {"errors": []}
     if not error_list:
-        logger().info(f"validate passed")
+        logger.info(f"validate passed")
         return jsonify(json)
     else:
-        logger().info(f"{len(error_list)} validation errors: [{error_list[0]!r}, ...]")
+        logger.info(f"{len(error_list)} validation errors: [{error_list[0]!r}, ...]")
         # The spreadsheet is invalid
         json["errors"] = error_list
         return jsonify(json)
@@ -249,7 +252,7 @@ def check_permissions(user, trial_id, template_type):
     if user.is_nci_user() and template_type in prism.SUPPORTED_MANIFESTS:
         return
     if not perm:
-        logger().info(
+        logger.info(
             f"Unauthorized attempt to access trial {trial_id} by {user.email!r}"
         )
         raise Unauthorized(
@@ -273,30 +276,30 @@ def upload_handler(allowed_types: List[str]):
     def inner(f):
         @wraps(f)
         def wrapped(*args, **kwargs):
-            logger().info(f"upload_handler({f.__name__}) started")
+            logger.info(f"upload_handler({f.__name__}) started")
             template, xlsx_file = extract_schema_and_xlsx(allowed_types)
 
             errors_so_far = []
 
             xlsx, errors = XlTemplateReader.from_excel(xlsx_file)
-            logger().info(f"xlsx parsed: {len(errors)} errors")
+            logger.info(f"xlsx parsed: {len(errors)} errors")
             for e in errors:
-                logger().info(f"\t{e}")
+                logger.info(f"\t{e}")
             errors_so_far.extend(errors)
 
             # Run basic validations on the provided Excel file
             validations = validate(template, xlsx)
-            logger().info(f"xlsx validated: {len(validations.json['errors'])} errors")
+            logger.info(f"xlsx validated: {len(validations.json['errors'])} errors")
             for e in validations.json["errors"]:
-                logger().info(f"\t{e}")
+                logger.info(f"\t{e}")
             errors_so_far.extend(validations.json["errors"])
 
             md_patch, file_infos, errors = prism.prismify(xlsx, template)
-            logger().info(
+            logger.info(
                 f"prismified: {len(errors)} errors, {len(file_infos)} file_infos"
             )
             for e in errors:
-                logger().info(f"\t{e}")
+                logger.info(f"\t{e}")
             errors_so_far.extend(errors)
 
             try:
@@ -336,18 +339,16 @@ def upload_handler(allowed_types: List[str]):
             except prism.InvalidMergeTargetException as e:
                 # we have an invalid MD stored in db - users can't do anything about it.
                 # So we log it
-                logger().info(
-                    f"Internal error with trial {trial_id!r}", file=sys.stderr
-                )
-                logger().info(e, file=sys.stderr)
+                logger.info(f"Internal error with trial {trial_id!r}", file=sys.stderr)
+                logger.info(e, file=sys.stderr)
                 # and return an error. Though it's not BadRequest but rather an
                 # Internal Server error we report it like that, so it will be displayed
                 raise BadRequest(
                     f"Internal error with {trial_id!r}. Please contact a CIDC Administrator."
                 ) from e
-            logger().info(f"merged: {len(errors)} errors")
+            logger.info(f"merged: {len(errors)} errors")
             for e in errors:
-                logger().info(f"\t{e}")
+                logger.info(f"\t{e}")
             errors_so_far.extend(errors)
 
             if errors_so_far:
@@ -483,7 +484,7 @@ def upload_data_files(
 
     # TODO: refactor this to be a pre-GET hook on the upload-jobs resource.
     """
-    logger().info(f"upload_assay started")
+    logger.info(f"upload_assay started")
     upload_moment = datetime.datetime.now().isoformat()
     uri2uuid = {}
     url_mapping = {}

--- a/cidc_api/shared/auth.py
+++ b/cidc_api/shared/auth.py
@@ -8,8 +8,10 @@ from flask import g, request, current_app as app, Flask
 from werkzeug.exceptions import Unauthorized, BadRequest, PreconditionFailed
 
 from ..models import Users, UserSchema
-from ..config.logging import logger
 from ..config.settings import AUTH0_DOMAIN, ALGORITHMS, AUTH0_CLIENT_ID, TESTING
+from ..config.logging import get_logger
+
+logger = get_logger(__name__)
 
 ### Main auth utility functions ###
 def validate_api_auth(app: Flask):
@@ -292,7 +294,7 @@ def _log_user_and_request_details(is_authorized: bool):
     user = get_current_user()
     log_msg += f" (user:{user.id}:{user.email})"
 
-    logger().info(log_msg)
+    logger.info(log_msg)
 
 
 def _enforce_cli_version():
@@ -309,7 +311,7 @@ def _enforce_cli_version():
     try:
         client, client_version = user_agent.split("/", 1)
     except ValueError:
-        logger().info(f"Unrecognized user-agent string format: {user_agent}")
+        logger.info(f"Unrecognized user-agent string format: {user_agent}")
         raise BadRequest("could not parse User-Agent string")
 
     # Old CLI versions don't update the User-Agent header, so we (perhaps dangerously)
@@ -324,7 +326,7 @@ def _enforce_cli_version():
     )
 
     if is_very_old_cli or is_old_cli:
-        logger().info("cancelling request: detected outdated CLI")
+        logger.info("cancelling request: detected outdated CLI")
         message = (
             "You appear to be using an out-of-date version of the CIDC CLI. "
             "Please upgrade to the most recent version:\n"

--- a/cidc_api/shared/auth.py
+++ b/cidc_api/shared/auth.py
@@ -294,7 +294,10 @@ def _log_user_and_request_details(is_authorized: bool):
     user = get_current_user()
     log_msg += f" (user:{user.id}:{user.email})"
 
-    logger.info(log_msg)
+    if is_authorized:
+        logger.info(log_msg)
+    else:
+        logger.error(log_msg)
 
 
 def _enforce_cli_version():
@@ -311,7 +314,7 @@ def _enforce_cli_version():
     try:
         client, client_version = user_agent.split("/", 1)
     except ValueError:
-        logger.info(f"Unrecognized user-agent string format: {user_agent}")
+        logger.error(f"Unrecognized user-agent string format: {user_agent}")
         raise BadRequest("could not parse User-Agent string")
 
     # Old CLI versions don't update the User-Agent header, so we (perhaps dangerously)

--- a/cidc_api/shared/gcloud_client.py
+++ b/cidc_api/shared/gcloud_client.py
@@ -10,7 +10,6 @@ from typing.io import BinaryIO
 import requests
 from google.cloud import storage, pubsub
 
-from ..config.logging import logger
 from ..config.settings import (
     GOOGLE_DOWNLOAD_ROLE,
     GOOGLE_UPLOAD_ROLE,
@@ -27,6 +26,9 @@ from ..config.settings import (
     DEV_CFUNCTIONS_SERVER,
     INACTIVE_USER_DAYS,
 )
+from ..config.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def _get_bucket(bucket_name: str) -> storage.Bucket:
@@ -70,7 +72,7 @@ def upload_xlsx_to_gcs(
     )
 
     if ENV == "dev":
-        logger().info(
+        logger.info(
             f"Would've saved {blob_name} to {GOOGLE_UPLOAD_BUCKET} and {GOOGLE_DATA_BUCKET}"
         )
         return _pseudo_blob(
@@ -95,15 +97,13 @@ def grant_upload_access(user_email: str):
     means a user can write objects to the bucket but cannot delete,
     overwrite, or read objects from this bucket.
     """
-    logger().info(f"granting upload to {user_email}")
+    logger.info(f"granting upload to {user_email}")
     bucket = _get_bucket(GOOGLE_UPLOAD_BUCKET)
 
     # Update the bucket IAM policy to include the user as an uploader.
     policy = bucket.get_iam_policy()
     policy[GOOGLE_UPLOAD_ROLE] = {*policy[GOOGLE_UPLOAD_ROLE], f"user:{user_email}"}
-    logger().info(
-        f"{GOOGLE_UPLOAD_ROLE} binding updated to {policy[GOOGLE_UPLOAD_ROLE]}"
-    )
+    logger.info(f"{GOOGLE_UPLOAD_ROLE} binding updated to {policy[GOOGLE_UPLOAD_ROLE]}")
     bucket.set_iam_policy(policy)
 
 
@@ -111,15 +111,13 @@ def revoke_upload_access(user_email: str):
     """
     Revoke a user's upload access for the given bucket.
     """
-    logger().info(f"revoking upload from {user_email}")
+    logger.info(f"revoking upload from {user_email}")
     bucket = _get_bucket(GOOGLE_UPLOAD_BUCKET)
 
     # Update the bucket IAM policy to remove the user's uploader privileges.
     policy = bucket.get_iam_policy()
     policy[GOOGLE_UPLOAD_ROLE].discard(f"user:{user_email}")
-    logger().info(
-        f"{GOOGLE_UPLOAD_ROLE} binding updated to {policy[GOOGLE_UPLOAD_ROLE]}"
-    )
+    logger.info(f"{GOOGLE_UPLOAD_ROLE} binding updated to {policy[GOOGLE_UPLOAD_ROLE]}")
     bucket.set_iam_policy(policy)
 
 
@@ -129,7 +127,7 @@ def grant_download_access(user_email: str, trial_id: str, upload_type: str):
     """
     url_prefix, prefix_expression = _build_prefix_clause(trial_id, upload_type)
 
-    logger().info(f"Granting download access on {url_prefix}* to {user_email}")
+    logger.info(f"Granting download access on {url_prefix}* to {user_email}")
 
     # get the current IAM policy for the data bucket
     bucket = _get_bucket(GOOGLE_DATA_BUCKET)
@@ -154,7 +152,7 @@ def revoke_download_access(user_email: str, trial_id: str, upload_type: str):
     """
     url_prefix, prefix_expression = _build_prefix_clause(trial_id, upload_type)
 
-    logger().info(f"Revoking download access on {url_prefix}* from {user_email}")
+    logger.info(f"Revoking download access on {url_prefix}* from {user_email}")
 
     # get the current IAM policy for the data bucket
     bucket = _get_bucket(GOOGLE_DATA_BUCKET)
@@ -309,7 +307,7 @@ def get_signed_url(
         method=method,
         response_disposition=f'attachment; filename="{full_filename}"',
     )
-    logger().info(f"generated signed URL for {object_name}: {url}")
+    logger.info(f"generated signed URL for {object_name}: {url}")
 
     return url
 
@@ -323,7 +321,7 @@ def _encode_and_publish(content: str, topic: str) -> Future:
     # Don't actually publish to Pub/Sub if running locally
     if ENV == "dev":
         if DEV_CFUNCTIONS_SERVER:
-            logger().info(
+            logger.info(
                 f"Publishing message {content!r} to topic {DEV_CFUNCTIONS_SERVER}/{topic}"
             )
             import base64
@@ -338,13 +336,13 @@ def _encode_and_publish(content: str, topic: str) -> Future:
                     f"Couldn't publish message {content!r} to topic {DEV_CFUNCTIONS_SERVER}/{topic}"
                 ) from e
             else:
-                logger().info(f"Got {res}")
+                logger.info(f"Got {res}")
                 if res.status_code != 200:
                     raise Exception(
                         f"Couldn't publish message {content!r} to {DEV_CFUNCTIONS_SERVER}/{topic}: {res!r}"
                     )
         else:
-            logger().info(f"Would've published message {content} to topic {topic}")
+            logger.info(f"Would've published message {content} to topic {topic}")
         return
 
     # The Pub/Sub publisher client returns a concurrent.futures.Future
@@ -389,7 +387,7 @@ def send_email(to_emails: List[str], subject: str, html_content: str, **kw):
     """
     # Don't actually send an email if this is a test
     if TESTING or ENV == "dev":
-        logger().info(f"Would send email with subject '{subject}' to {to_emails}")
+        logger.info(f"Would send email with subject '{subject}' to {to_emails}")
         return
 
     email_json = json.dumps(

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -8,3 +8,5 @@ port = os.environ.get("PORT", 8080)
 loglevel = "DEBUG" if is_dev else "INFO"
 reload = is_dev
 timeout = 60
+# Send all logs to stdout (where App Engine reads them from)
+errorlog = "-"

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -20,9 +20,7 @@ keys = console
 keys = generic
 
 [logger_root]
-level = WARN
-handlers = console
-qualname =
+handlers =
 
 [logger_sqlalchemy]
 level = WARN
@@ -31,7 +29,7 @@ qualname = sqlalchemy.engine
 
 [logger_alembic]
 level = DEBUG
-handlers = 
+handlers =
 qualname = alembic
 
 [handler_console]

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,6 +1,8 @@
 from __future__ import with_statement
 
+import sys
 import logging
+from logging import StreamHandler
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
@@ -14,8 +16,9 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+fileConfig(config.config_file_name, disable_existing_loggers=False)
 logger = logging.getLogger("alembic.env")
+logger.info("hello friends")
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
Improvements on #340 based on post-merge feedback 😅

This PR updates logging to no longer use Flask's built-in logger, opting instead for module-level logging, configured via the `cidc_api.config.logging.get_logger` function.

Also, I tried to find the places we'd want to log at the `ERROR` level and update them appropriately.