### PR TITLE
Add filter-responsive file counts to facets

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -1005,9 +1005,6 @@ class UploadJobs(CommonColumns):
             self.alert_upload_success(trial)
 
 
-import time
-
-
 class DownloadableFiles(CommonColumns):
     """
     Store required fields from:

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -36,15 +36,15 @@ from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.query import Query
-from sqlalchemy.sql import expression, text
+from sqlalchemy.sql import text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.engine import ResultProxy
-from sqlalchemy.engine.interfaces import ExecutionContext
 
 from cidc_schemas import prism, unprism, json_validation
-from sqlalchemy.sql.elements import literal
 
 from .files import (
+    build_trial_facets,
+    build_data_category_facets,
     get_facet_groups_for_paths,
     facet_groups_to_names,
     details_dict,
@@ -63,10 +63,8 @@ from ..config.settings import (
 from ..shared import emails
 from ..shared.gcloud_client import (
     publish_artifact_upload,
-    publish_upload_success,
     grant_download_access,
     revoke_download_access,
-    send_email,
 )
 from ..config.logging import get_logger
 
@@ -204,6 +202,20 @@ class CommonColumns(BaseModel):  # type: ignore
         """Return the total number of records in this table."""
         filtered_query = filter_(session.query(cls.id))
         return filtered_query.count()
+
+    @classmethod
+    @with_default_session
+    def count_by(
+        cls, expr, session: Session, filter_: Callable[[Query], Query] = lambda q: q
+    ) -> Dict[str, int]:
+        """
+        Return a dictionary mapping results of `expr` to the number of times each result
+        occurs in the table related to this model. E.g., for the `UploadJobs` model, 
+        `UploadJobs.count_by_column(UploadJobs.upload_type)` would return a dictionary mapping
+        upload types to the number of jobs for each type.
+        """
+        results = filter_(session.query(expr, func.count(cls.id)).group_by(expr)).all()
+        return dict(results)
 
     @classmethod
     @with_default_session
@@ -993,6 +1005,9 @@ class UploadJobs(CommonColumns):
             self.alert_upload_success(trial)
 
 
+import time
+
+
 class DownloadableFiles(CommonColumns):
     """
     Store required fields from:
@@ -1364,6 +1379,31 @@ class DownloadableFiles(CommonColumns):
         """Get the total number of bytes of data stored across all files."""
         total_bytes = session.query(func.sum(cls.file_size_bytes)).one()[0]
         return int(total_bytes)
+
+    @classmethod
+    @with_default_session
+    def get_trial_facets(
+        cls, session: Session, filter_: Callable[[Query], Query] = lambda q: q
+    ):
+        trial_file_counts = cls.count_by(
+            cls.trial_id,
+            session=session,
+            # Apply the provided filter, and also exclude files with null `data_category`s
+            filter_=lambda q: filter_(q).filter(cls.data_category != None),
+        )
+        trial_facets = build_trial_facets(trial_file_counts)
+        return trial_facets
+
+    @classmethod
+    @with_default_session
+    def get_data_category_facets(
+        cls, session: Session, filter_: Callable[[Query], Query] = lambda q: q
+    ):
+        data_category_file_counts = cls.count_by(
+            cls.data_category, session=session, filter_=filter_
+        )
+        data_category_facets = build_data_category_facets(data_category_file_counts)
+        return data_category_facets
 
 
 # Query clause for computing a downloadable file's data category.

--- a/tests/models/files/test_facets.py
+++ b/tests/models/files/test_facets.py
@@ -1,33 +1,56 @@
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.util.langhelpers import NoneType
 from werkzeug.exceptions import BadRequest
 
 from cidc_api.models.files.facets import (
     facets_dict,
-    get_facet_info,
+    build_trial_facets,
+    build_data_category_facets,
     get_facet_groups_for_paths,
 )
 
 
-def test_get_facet_info():
-    """Ensure get_facet_labels returns an object with the expected structure."""
+def assert_expected_facet_structure(config: dict):
+    assert isinstance(config.get("label"), str)
+    assert isinstance(config.get("description"), (str, NoneType))
+    assert isinstance(config.get("count"), int)
 
-    def test_info_structure(config: dict):
-        assert "label" in config
-        assert "description" in config
 
-    labels = get_facet_info()
-    for value in labels.values():
+def test_build_data_category_facets():
+    """Ensure build_data_category_facets works as expected."""
+
+    wes_count = 5
+    sample_count = 12
+    data_category_file_counts = {"WES|Source": wes_count, "Samples Info": sample_count}
+
+    facet_specs = build_data_category_facets(data_category_file_counts)
+    for value in facet_specs.values():
         if isinstance(value, dict):
-            for subvalue in value.values():
+            for value_key, subvalue in value.items():
                 assert isinstance(subvalue, list)
                 for config in subvalue:
-                    test_info_structure(config)
+                    if value_key == "WES" and config["label"] == "Source":
+                        assert config["count"] == wes_count
+                    assert_expected_facet_structure(config)
         else:
             assert isinstance(value, list)
             for config in value:
-                test_info_structure(config)
+                if config["label"] == "Samples Info":
+                    assert config["count"] == sample_count
+                assert_expected_facet_structure(config)
+
+
+def test_build_trial_facets():
+    """Ensure build_trial_facets works as expected."""
+    trial_file_counts = {"t1": 1, "t2": 2, "t3": 3}
+    trial_facets = build_trial_facets(trial_file_counts)
+    assert trial_facets == [
+        {"label": "t1", "count": trial_file_counts["t1"]},
+        {"label": "t2", "count": trial_file_counts["t2"]},
+        {"label": "t3", "count": trial_file_counts["t3"]},
+    ]
 
 
 def test_get_facet_groups_for_paths():

--- a/tests/models/files/test_facets.py
+++ b/tests/models/files/test_facets.py
@@ -1,7 +1,4 @@
-from unittest.mock import MagicMock
-
 import pytest
-from sqlalchemy.util.langhelpers import NoneType
 from werkzeug.exceptions import BadRequest
 
 from cidc_api.models.files.facets import (
@@ -12,18 +9,17 @@ from cidc_api.models.files.facets import (
 )
 
 
-def assert_expected_facet_structure(config: dict):
-    assert isinstance(config.get("label"), str)
-    assert isinstance(config.get("description"), (str, NoneType))
-    assert isinstance(config.get("count"), int)
-
-
 def test_build_data_category_facets():
     """Ensure build_data_category_facets works as expected."""
 
     wes_count = 5
     sample_count = 12
     data_category_file_counts = {"WES|Source": wes_count, "Samples Info": sample_count}
+
+    def assert_expected_facet_structure(config: dict, count: int = 0):
+        assert "label" in config
+        assert "description" in config
+        assert config["count"] == count
 
     facet_specs = build_data_category_facets(data_category_file_counts)
     for value in facet_specs.values():
@@ -32,14 +28,16 @@ def test_build_data_category_facets():
                 assert isinstance(subvalue, list)
                 for config in subvalue:
                     if value_key == "WES" and config["label"] == "Source":
-                        assert config["count"] == wes_count
-                    assert_expected_facet_structure(config)
+                        assert_expected_facet_structure(config, wes_count)
+                    else:
+                        assert_expected_facet_structure(config)
         else:
             assert isinstance(value, list)
             for config in value:
                 if config["label"] == "Samples Info":
-                    assert config["count"] == sample_count
-                assert_expected_facet_structure(config)
+                    assert_expected_facet_structure(config, sample_count)
+                else:
+                    assert_expected_facet_structure(config)
 
 
 def test_build_trial_facets():

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -304,10 +304,47 @@ def test_get_filter_facets(cidc_api, clean_db, monkeypatch):
 
     client = cidc_api.test_client()
 
+    def check_facet_counts(facets, wes_count=0, cytof_count=0):
+        for facet, subfacets in facets["Assay Type"].items():
+            for subfacet in subfacets:
+                if facet == "WES" and subfacet["label"] == "Source":
+                    assert subfacet["count"] == wes_count
+                elif facet == "CyTOF" and subfacet["label"] == "Analysis Results":
+                    assert subfacet["count"] == cytof_count
+                else:
+                    assert subfacet["count"] == 0
+
+    # Non-admins' facets take into account their permissions
+    with cidc_api.app_context():
+        perm = Permissions(
+            granted_to_user=user_id,
+            trial_id=trial_id,
+            upload_type=upload_types[0],
+            granted_by_user=user_id,
+        )
+        perm.insert()
     res = client.get("/downloadable_files/filter_facets")
     assert res.status_code == 200
-    assert res.json["trial_ids"] == [trial_id]
-    assert isinstance(res.json["facets"], dict)
+    check_facet_counts(res.json["facets"], wes_count=1, cytof_count=0)
+
+    # Admins' facets include all files, regardless of permissions
+    make_admin(user_id, cidc_api)
+    res = client.get("/downloadable_files/filter_facets")
+    assert res.status_code == 200
+    assert res.json["trial_ids"] == [{"label": trial_id, "count": 2}]
+    check_facet_counts(res.json["facets"], wes_count=1, cytof_count=1)
+
+    # Trial facets are governed by data category facets
+    res = client.get("/downloadable_files/filter_facets?facets=Assay Type|WES|Germline")
+    assert res.status_code == 200
+    assert res.json["trial_ids"] == []
+    check_facet_counts(res.json["facets"], wes_count=1, cytof_count=1)
+
+    # Data category facets are governed by trial facets
+    res = client.get("/downloadable_files/filter_facets?trial_ids=someothertrial")
+    assert res.status_code == 200
+    res.json["trial_ids"] == []
+    check_facet_counts(res.json["facets"], wes_count=0, cytof_count=0)
 
 
 def test_get_download_url(cidc_api, clean_db, monkeypatch):


### PR DESCRIPTION
Now, available file facets are returned with file count metadata, where each facet's `"count"` field corresponds to the additional results that would be added to a search if a user selects that facet's filter.

Trial facet counts are filtered by the user's selected data category filters, and data category facet counts are filtered by the user's selected trial filters.