### PR TITLE
Refresh download permissions

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -493,10 +493,10 @@ class Permissions(CommonColumns):
 
     @staticmethod
     @with_default_session
-    def refresh_iam_permissions(user: Users, session: Session):
+    def grant_iam_permissions(user: Users, session: Session):
         """
-        Regrant each of the given `user`'s IAM permissions to extend
-        their expiry date.
+        Grant each of the given `user`'s IAM permissions. If the permissions
+        have already been granted, calling this will extend their expiry date.
         """
         filter_for_user = lambda q: q.filter(Permissions.granted_to_user == user.id)
         perms = Permissions.list(

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -493,6 +493,24 @@ class Permissions(CommonColumns):
 
     @staticmethod
     @with_default_session
+    def refresh_iam_permissions(user: Users, session: Session):
+        """
+        Regrant each of the given `user`'s IAM permissions to extend
+        their expiry date.
+        """
+        filter_for_user = lambda q: q.filter(Permissions.granted_to_user == user.id)
+        perms = Permissions.list(
+            page_size=Permissions.count(session=session, filter_=filter_for_user),
+            filter_=filter_for_user,
+            session=session,
+        )
+        for perm in perms:
+            # Regrant each permission to reset the TTL for this permission to
+            # `settings.INACTIVE_USER_DAYS` from today.
+            grant_download_access(user.email, perm.trial_id, perm.upload_type)
+
+    @staticmethod
+    @with_default_session
     def grant_all_iam_permissions(session: Session):
         Permissions._change_all_iam_permissions(grant=True, session=session)
 
@@ -507,7 +525,7 @@ class Permissions(CommonColumns):
         perms = Permissions.list(page_size=Permissions.count(), session=session)
         for perm in perms:
             user = Users.find_by_id(perm.granted_to_user)
-            if user.is_admin() or user.is_nci_user():
+            if user.is_admin() or user.is_nci_user() or user.disabled:
                 continue
             if grant:
                 grant_download_access(user.email, perm.trial_id, perm.upload_type)

--- a/cidc_api/resources/users.py
+++ b/cidc_api/resources/users.py
@@ -118,7 +118,7 @@ def update_user(user: Users, user_updates: Users):
     # refresh their IAM download permissions.
     if user.disabled and user_updates.get("disabled") == False:
         user_updates["_accessed"] = datetime.now()
-        Permissions.refresh_iam_permissions(user)
+        Permissions.grant_iam_permissions(user)
 
     user.update(changes=user_updates)
 

--- a/cidc_api/resources/users.py
+++ b/cidc_api/resources/users.py
@@ -13,7 +13,14 @@ from ..shared.rest_utils import (
     unmarshal_request,
     use_args_with_pagination,
 )
-from ..models import Users, UserSchema, UserListSchema, CIDCRole, IntegrityError
+from ..models import (
+    Users,
+    UserSchema,
+    UserListSchema,
+    CIDCRole,
+    IntegrityError,
+    Permissions,
+)
 
 users_bp = Blueprint("users", __name__)
 
@@ -106,10 +113,12 @@ def update_user(user: Users, user_updates: Users):
     if not user.role and "role" in user_updates:
         user_updates["approval_date"] = datetime.now()
 
-    # If a user is being reenabled after being disabled, update their last
-    # access date to now so that they aren't disabled again tomorrow.
+    # If this user is being re-enabled after being disabled, update their last
+    # access date to now so that they aren't disabled again tomorrow and
+    # refresh their IAM download permissions.
     if user.disabled and user_updates.get("disabled") == False:
         user_updates["_accessed"] = datetime.now()
+        Permissions.refresh_iam_permissions(user)
 
     user.update(changes=user_updates)
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         "cidc_api.models.files",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.22.13",
+    version="0.22.14",
     zip_safe=False,
 )

--- a/tests/resources/test_users.py
+++ b/tests/resources/test_users.py
@@ -186,7 +186,7 @@ def test_update_user(cidc_api, clean_db, monkeypatch):
 
     # Reenabling a disabled user updates that user's last access date.
     mock_permissions = MagicMock()
-    mock_permissions.refresh_iam_permissions = MagicMock()
+    mock_permissions.grant_iam_permissions = MagicMock()
     monkeypatch.setattr("cidc_api.resources.users.Permissions", mock_permissions)
     res = client.patch(
         f"/users/{other_user.id}",
@@ -201,7 +201,7 @@ def test_update_user(cidc_api, clean_db, monkeypatch):
     )
     assert res.status_code == 200
     assert res.json["_accessed"] > _accessed
-    mock_permissions.refresh_iam_permissions.assert_called()
+    mock_permissions.grant_iam_permissions.assert_called()
 
     # Trying to update a non-existing user yields 404
     res = client.patch(

--- a/tests/resources/test_users.py
+++ b/tests/resources/test_users.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Tuple
+from unittest.mock import MagicMock
 
 from cidc_api.models import Users, UserSchema, CIDCRole
 
@@ -184,6 +185,9 @@ def test_update_user(cidc_api, clean_db, monkeypatch):
     _accessed = res.json["_accessed"]
 
     # Reenabling a disabled user updates that user's last access date.
+    mock_permissions = MagicMock()
+    mock_permissions.refresh_iam_permissions = MagicMock()
+    monkeypatch.setattr("cidc_api.resources.users.Permissions", mock_permissions)
     res = client.patch(
         f"/users/{other_user.id}",
         headers={"If-Match": res.json["_etag"]},
@@ -197,6 +201,7 @@ def test_update_user(cidc_api, clean_db, monkeypatch):
     )
     assert res.status_code == 200
     assert res.json["_accessed"] > _accessed
+    mock_permissions.refresh_iam_permissions.assert_called()
 
     # Trying to update a non-existing user yields 404
     res = client.patch(


### PR DESCRIPTION
* Add a new method `Permissions.refresh_iam_permissions` that extends the TTLs on a given user's GCS download permissions. 
* Refresh a user's GCS download permissions when an admin reactivates their account via the `/users` endpoint.

Up next: a daily cloud function that refreshes active users' download permissions to keep their IAM permissions (more) in-sync with their account status.