### PR TITLE
Add plotly dash proof-of-concept

### DIFF
--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -13,6 +13,7 @@ from .config.settings import SETTINGS
 from .config.logging import get_logger
 from .shared.auth import validate_api_auth
 from .resources import register_resources
+from .dash_example import init_dash
 
 logger = get_logger(__name__)
 
@@ -63,6 +64,8 @@ def handle_errors(e: Exception):
 
     return response
 
+
+init_dash(app)
 
 if __name__ == "__main__":
     app.run(host="127.0.0.1", port=5000)

--- a/cidc_api/dash_example.py
+++ b/cidc_api/dash_example.py
@@ -1,0 +1,125 @@
+import dash
+import dash_table as dt
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Output, Input
+from flask import Flask, request
+from sqlalchemy.sql.selectable import Select
+
+from cidc_api.models import (
+    UploadJobSchema,
+    UploadJobStatus,
+    UploadJobs,
+    CIDCRole,
+    TrialMetadata,
+)
+from cidc_api.config.settings import MAX_PAGINATION_PAGE_SIZE
+from cidc_api.shared.auth import requires_auth
+
+# This HTML template overrides Dash's default to enable passing values
+# (e.g., a user's identity token) in the JSON body of all Dash ajax requests
+# via URL query params. For example, loading a Dash dashboard like so:
+#
+#   <iframe src="https://api.cimac-network.org/dashboard-url?id_token=foo&some_param=bar" />
+#
+# will automatically insert {"id_token": "foo", "some_param": "bar"} into the
+# JSON body of every ajax request the dashboard makes after loading into the iframe.
+# This is useful for a) performing user authentication and authorization and
+# b) parameterizing dashboards (i.e., having a generic trial dashboard that takes
+# a protocol identifier as a parameter to determine what to render).
+#
+# The operative code here is in the <script id="_dash-renderer">...</script> tag.
+index_string = """
+    <!DOCTYPE html>
+    <html>
+        <head>
+            {%metas%}
+            <title>{%title%}</title>
+            {%favicon%}
+            {%css%}
+        </head>
+        <body>
+            {%app_entry%}
+            <footer>
+                {%config%}
+                {%scripts%}
+                <script id="_dash-renderer">
+                    const urlParams = new URLSearchParams(window.location.search);
+                    const renderer = new DashRenderer({
+                        request_pre: (req) => {
+                            for (const [param, value] of urlParams.entries()) {
+                                req[param] = value;
+                            }
+                        },
+                        request_post: (req, res) => {}
+                    })
+                </script>
+            </footer>
+        </body>
+    </html>
+"""
+
+UPLOAD_JOB_TABLE_ID = "upload-job-table"
+TRIAL_ID_DROPDOWN_ID = "trial-id-dropdown"
+NO_INPUT_ID = "force-callback-no-inputs"
+
+layout = html.Div(
+    [
+        dcc.Dropdown(
+            id=TRIAL_ID_DROPDOWN_ID,
+            placeholder="Select protocol identifiers",
+            multi=True,
+        ),
+        dt.DataTable(id=UPLOAD_JOB_TABLE_ID),
+        # This input remains hidden from the user and is used
+        # to allow adding component callbacks
+        dcc.Input(id=NO_INPUT_ID, type="hidden"),
+    ]
+)
+
+# Add this to a dash callback without inputs to ensure
+# the callback gets called once when the dashboard first loads.
+NoInputs = Input(NO_INPUT_ID, "value")
+
+upload_jobs_schema = UploadJobSchema(exclude=["metadata_patch"])
+
+
+def init_dash(app: Flask):
+    dash_app = dash.Dash(
+        server=app,
+        url_base_pathname="/dashboards/upload_jobs/",
+        index_string=index_string,
+    )
+    dash_app.layout = layout
+
+    @dash_app.callback(Output(TRIAL_ID_DROPDOWN_ID, "options"), NoInputs)
+    @requires_auth("dash.trial_ids", [CIDCRole.ADMIN.value])
+    def populate_trial_ids(_):
+        """Load available trial_ids into the trial id dropdown."""
+        return [
+            {"label": t, "value": t} for t in TrialMetadata.get_distinct("trial_id")
+        ]
+
+    @dash_app.callback(
+        [Output(UPLOAD_JOB_TABLE_ID, "columns"), Output(UPLOAD_JOB_TABLE_ID, "data")],
+        [Input(TRIAL_ID_DROPDOWN_ID, "value")],
+    )
+    @requires_auth("dash.upload_jobs", [CIDCRole.ADMIN.value])
+    def upload_jobs_table(selected_trial_ids):
+        """Load successful upload jobs for the selected trials."""
+        columns = [
+            {"name": "Trial ID", "id": "trial_id"},
+            {"name": "Upload Type", "id": "upload_type"},
+            {"name": "Uploader", "id": "uploader_email"},
+            {"name": "Date", "id": "_updated"},
+        ]
+        upload_jobs = UploadJobs.list(
+            page_size=MAX_PAGINATION_PAGE_SIZE,
+            sort_field="_updated",
+            sort_direction="desc",
+            filter_=lambda q: q.filter(
+                UploadJobs.status == UploadJobStatus.MERGE_COMPLETED.value,
+                not selected_trial_ids or UploadJobs.trial_id.in_(selected_trial_ids),
+            ),
+        )
+        return (columns, upload_jobs_schema.dump(upload_jobs, many=True))

--- a/cidc_api/resources/upload_jobs.py
+++ b/cidc_api/resources/upload_jobs.py
@@ -1,4 +1,3 @@
-import sys
 import datetime
 from typing import BinaryIO, Tuple, List
 from functools import wraps

--- a/cidc_api/shared/auth.py
+++ b/cidc_api/shared/auth.py
@@ -139,14 +139,19 @@ def authenticate() -> Users:
 
 
 def _extract_token() -> str:
-    """Extract an identity token from the current request's authorization header."""
+    """Extract an identity token from the current request's authorization header or from the request body."""
+    auth_header = request.headers.get("Authorization")
+
     try:
-        auth_header = request.headers.get("Authorization")
-        bearer, id_token = auth_header.split(" ")
-        assert bearer.lower() == "bearer"
+        if auth_header:
+            bearer, id_token = auth_header.split(" ")
+            assert bearer.lower() == "bearer"
+        else:
+            id_token = request.json["id_token"]
     except:
         raise Unauthorized(
-            "Authorization header must be set with structure 'Authorization: Bearer <id token>'"
+            "Either the 'Authorization' header must be set with structure 'Authorization: Bearer <id token>' "
+            'or "id_token" must be present in the JSON body of the request.'
         )
 
     return id_token

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ psycopg2-binary==2.8.3
 packaging==19.2
 gunicorn
 webargs==6.0.0
+dash==1.18.1
 -r requirements.modules.txt

--- a/tests/resources/test_upload_jobs.py
+++ b/tests/resources/test_upload_jobs.py
@@ -701,7 +701,7 @@ def test_upload_wes(cidc_api, clean_db, monkeypatch):
     mocks = UploadMocks(
         monkeypatch,
         prismify_file_entries=[
-            finfo("localfile.ext", "test_trial/url/file.ext", "uuid-1", None)
+            finfo("localfile.ext", "test_trial/url/file.ext", "uuid-1", None, False)
         ],
     )
 
@@ -805,7 +805,7 @@ def test_upload_olink(cidc_api, clean_db, monkeypatch):
     mocks = UploadMocks(
         monkeypatch,
         prismify_file_entries=[
-            finfo(lp, url, "uuid" + str(i), "npx" in url)
+            finfo(lp, url, "uuid" + str(i), "npx" in url, False)
             for i, (lp, url) in enumerate(OLINK_TESTDATA)
         ],
     )

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -235,10 +235,16 @@ def test_authenticate(empty_app, monkeypatch):
 
 def test_extract_token(empty_app):
     """Test that _extract_token handles edge cases"""
+    token = "Case-Sensitive-Test-Token"
+
     # No auth header
     with empty_app.test_request_context("/"):
         with pytest.raises(Unauthorized):
             auth._extract_token()
+
+    # No auth header but id_token present in JSON request body
+    with empty_app.test_request_context("/", json={"id_token": token}):
+        assert auth._extract_token() == token
 
     # Non-bearer auth headers
     with empty_app.test_request_context("/", headers={"authorization": ""}):
@@ -254,7 +260,6 @@ def test_extract_token(empty_app):
             auth._extract_token()
 
     # Well-formed auth header
-    token = "Case-Sensitive-Test-Token"
     with empty_app.test_request_context(
         "/", headers={"authorization": f"Bearer {token}"}
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -442,7 +442,13 @@ def test_endpoint_urls(cidc_api):
     }
 
     # Check that every endpoint included in the API is expected.
-    endpoints = set([rule.rule for rule in cidc_api.url_map._rules])
+    endpoints = set(
+        [
+            rule.rule
+            for rule in cidc_api.url_map._rules
+            if not "/dashboards/" in rule.rule  # exclude plotly dash dashboards
+        ]
+    )
     assert endpoints == expected_endpoints
 
 


### PR DESCRIPTION
This PR adds a one-off example of an auth-protected Plotly Dash dashboard to the API. In order to authenticate Dash requests, I had to update our `auth` module to accept user identity tokens via the JSON body of client requests in addition to the `Authorization` header.

If we decide to move forward with Plotly Dash, I intend to make some kind of microframework (or just a set of helper methods) to simplify the process of adding new dashboards to the API in a future PR.

See corresponding UI PR: https://github.com/CIMAC-CIDC/cidc-ui/pull/345