### PR TITLE
And handling for non-dict/list entries; and edit corresponding test

### DIFF
--- a/cidc_api/resources/upload_jobs.py
+++ b/cidc_api/resources/upload_jobs.py
@@ -195,7 +195,7 @@ def _remove_optional_uuid_recursive(target: dict, uuid: str):
             ):
                 target.pop(k)
                 return target
-            else:
+            elif isinstance(v, (dict, list)):
                 temp = _remove_optional_uuid_recursive(v, uuid)
                 if len(temp):
                     target[k] = temp

--- a/tests/resources/test_upload_jobs.py
+++ b/tests/resources/test_upload_jobs.py
@@ -1303,6 +1303,7 @@ def test_remove_optional_uuid_recursive():
             {"upload_placeholder": "one-deep array"},
             {"upload_placeholder": "second item"},
         ],
+        "int": 4,
     }
 
     this_test = deepcopy(test)
@@ -1363,4 +1364,4 @@ def test_remove_optional_uuid_recursive():
     temp = _remove_optional_uuid_recursive(temp, "one-deep array")
     assert not DeepDiff(temp, this_test)
     temp = _remove_optional_uuid_recursive(temp, "second item")
-    assert not temp
+    assert not DeepDiff(temp, {"int": 4})


### PR DESCRIPTION
Found in testing mIF upload
Didn't handle if len(value) errors
Specify only for dict and list, which will never error