### PR TITLE
Create an intake bucket per user

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -511,7 +511,7 @@ class Permissions(CommonColumns):
             grant_download_access(user.email, perm.trial_id, perm.upload_type)
 
         # Regrant all of the user's intake bucket upload permissions, if they have any
-        refresh_intake_access(user.id, user.email)
+        refresh_intake_access(user.email)
 
     @staticmethod
     @with_default_session

--- a/cidc_api/resources/upload_jobs.py
+++ b/cidc_api/resources/upload_jobs.py
@@ -677,17 +677,16 @@ INTAKE_ROLES = [
 ]
 
 
-@ingestion_bp.route("/intake_gcs_uri", methods=["POST"])
-@requires_auth("intake_gcs_uri", INTAKE_ROLES)
+@ingestion_bp.route("/intake_bucket", methods=["POST"])
+@requires_auth("intake_bucket", INTAKE_ROLES)
 @use_args(
     {"trial_id": fields.Str(required=True), "upload_type": fields.Str(required=True)}
 )
-def create_intake_gcs_uri(args):
+def create_intake_bucket(args):
     """
-    Grant upload access to the current user for the provided trial and upload types,
-    returning the GCS URI the user now has permission to upload to.
-    NOTE: we don't verify that the user has permission to upload data for this trial-upload 
-    type combo because they won't be able to overwrite any other user's uploaded data.
+    Create an intake bucket for the current user if one doesn't exist yet, and return
+    both the `gs://...` and web console URLs to the subdirectory in this bucket that we
+    want the user to upload to (for the given trial / upload type combination).
     """
     user = get_current_user()
     intake_bucket = gcloud_client.create_intake_bucket(user.email)

--- a/cidc_api/shared/emails.py
+++ b/cidc_api/shared/emails.py
@@ -1,4 +1,5 @@
 """Template functions for CIDC email bodies."""
+import html
 import base64
 from functools import wraps
 
@@ -128,10 +129,10 @@ def intake_metadata(
     html_content = f"""
     <p><strong>user:</strong> {user.first_n} {user.last_n} ({user.email})</p>
     <p><strong>contact email:</strong> {user.contact_email}</p>
-    <p><strong>protocol identifier:</strong> {trial_id}</p>
-    <p><strong>assay type:</strong> {assay_type}</p>
+    <p><strong>protocol identifier:</strong> {html.escape(trial_id)}</p>
+    <p><strong>assay type:</strong> {html.escape(assay_type)}</p>
     <p><strong>metadata file:</strong> <a href={xlsx_gcp_url}>{xlsx_gcp_url}</a></p>
-    <p><strong>description:</strong> {description}</p>
+    <p><strong>description:</strong> {html.escape(description)}</p>
     """
 
     email = {

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         "cidc_api.models.files",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.22.18",
+    version="0.23.0",
     zip_safe=False,
 )

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -917,7 +917,7 @@ def test_permissions_grant_iam_permissions(clean_db, monkeypatch):
         [call(user.email, trial.trial_id, upload_type) for upload_type in upload_types]
     )
 
-    refresh_intake_access.assert_called_once_with(user.id, user.email)
+    refresh_intake_access.assert_called_once_with(user.email)
 
 
 @db_test

--- a/tests/resources/test_upload_jobs.py
+++ b/tests/resources/test_upload_jobs.py
@@ -1105,7 +1105,7 @@ def test_merge_extra_metadata(cidc_api, clean_db, monkeypatch):
         assert "extra_md" in au.metadata_patch["whatever"]["hierarchy"][1]
 
 
-def test_create_intake_gcs_uri(cidc_api, clean_db, monkeypatch):
+def test_create_intake_bucket(cidc_api, clean_db, monkeypatch):
     user_id = setup_trial_and_user(cidc_api, monkeypatch)
     bucket_name = "test-intake-bucket"
 
@@ -1121,7 +1121,7 @@ def test_create_intake_gcs_uri(cidc_api, clean_db, monkeypatch):
     for role in ROLES:
         make_role(user_id, role, cidc_api)
         res = client.post(
-            "/ingestion/intake_gcs_uri",
+            "/ingestion/intake_bucket",
             json={"trial_id": "test-trial", "upload_type": "test-upload"},
         )
         if role in INTAKE_ROLES:

--- a/tests/resources/test_upload_jobs.py
+++ b/tests/resources/test_upload_jobs.py
@@ -1107,10 +1107,13 @@ def test_merge_extra_metadata(cidc_api, clean_db, monkeypatch):
 
 def test_create_intake_gcs_uri(cidc_api, clean_db, monkeypatch):
     user_id = setup_trial_and_user(cidc_api, monkeypatch)
+    bucket_name = "test-intake-bucket"
 
     gcloud_client = MagicMock()
-    gcloud_client.grant_intake_access = MagicMock()
-    gcloud_client.grant_intake_access.return_value = "gs://some-uri"
+    gcloud_client.create_intake_bucket = MagicMock()
+    bucket = MagicMock()
+    bucket.name = bucket_name
+    gcloud_client.create_intake_bucket.return_value = bucket
     monkeypatch.setattr("cidc_api.resources.upload_jobs.gcloud_client", gcloud_client)
 
     client = cidc_api.test_client()
@@ -1123,36 +1126,14 @@ def test_create_intake_gcs_uri(cidc_api, clean_db, monkeypatch):
         )
         if role in INTAKE_ROLES:
             assert res.status_code == 200
-            gcloud_client.grant_intake_access.assert_called_with(
-                user_id, user_email, "test-trial", "test-upload"
-            )
-            assert res.json == "gs://some-uri"
+            gcloud_client.create_intake_bucket.assert_called_with(user_email)
+            assert res.json == {
+                "gs_url": f"gs://{bucket_name}/test-trial/test-upload",
+                "console_url": f"https://console.cloud.google.com/storage/browser/{bucket_name}/test-trial/test-upload",
+            }
         else:
             assert res.status_code == 401
-        gcloud_client.grant_intake_access.reset_mock()
-
-
-def test_list_intake_gcs_uris(cidc_api, clean_db, monkeypatch):
-    user_id = setup_trial_and_user(cidc_api, monkeypatch)
-
-    uris = ["gs://a", "gs://b", "gs://c"]
-    gcloud_client = MagicMock()
-    gcloud_client.list_intake_access = MagicMock()
-    gcloud_client.list_intake_access.return_value = uris
-    monkeypatch.setattr("cidc_api.resources.upload_jobs.gcloud_client", gcloud_client)
-
-    client = cidc_api.test_client()
-
-    for role in ROLES:
-        make_role(user_id, role, cidc_api)
-        res = client.get("/ingestion/intake_gcs_uri")
-        if role in INTAKE_ROLES:
-            assert res.status_code == 200
-            gcloud_client.list_intake_access.assert_called_with(user_email)
-            assert res.json == {"_items": uris, "_meta": {"total": len(uris)}}
-        else:
-            assert res.status_code == 401
-        gcloud_client.grant_intake_access.reset_mock()
+        gcloud_client.create_intake_bucket.reset_mock()
 
 
 def test_send_intake_metadata(cidc_api, clean_db, monkeypatch):

--- a/tests/shared/test_emails.py
+++ b/tests/shared/test_emails.py
@@ -1,8 +1,6 @@
 from io import BytesIO
 from unittest.mock import MagicMock
 
-from werkzeug.datastructures import FileStorage
-
 from cidc_api.models import Users, UploadJobs
 from cidc_api.shared.emails import (
     confirm_account_approval,
@@ -80,7 +78,7 @@ def test_intake_metadata():
     )
     trial_id = "10021"
     assay_type = "wes"
-    description = "a test description of this metadata"
+    description = "a test description of this <a>metadata</a>"
     xlsx_uri = "gs://fake/gcs/uri"
 
     email = intake_metadata(user, trial_id, assay_type, description, xlsx_uri)
@@ -88,5 +86,9 @@ def test_intake_metadata():
     assert f"{user.first_n} {user.last_n}" in email["html_content"]
     assert f"{user.email}" in email["html_content"]
     assert f"{user.contact_email}" in email["html_content"]
-    assert f"{description}" in email["html_content"]
+    # sketchy html in the provided description should be escaped
+    assert (
+        f"a test description of this &lt;a&gt;metadata&lt;/a&gt;"
+        in email["html_content"]
+    )
     assert f"{xlsx_uri}" in email["html_content"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -428,7 +428,7 @@ def test_endpoint_urls(cidc_api):
         "/ingestion/upload_analysis",
         "/ingestion/extra-assay-metadata",
         "/ingestion/poll_upload_merge_status/<int:upload_job>",
-        "/ingestion/intake_gcs_uri",
+        "/ingestion/intake_bucket",
         "/ingestion/intake_metadata",
         "/permissions/",
         "/permissions/<int:permission>",


### PR DESCRIPTION
...instead of granting uploaders conditional access on subdirectories of a single intake bucket. 

This change will allow users to upload their files directly via the GCS console UI and should fix IAM issues with the current implementation.

This PR contains breaking changes to the `/ingestion/intake_gcs_uri` endpoint and should be merged alongside https://github.com/CIMAC-CIDC/cidc-ui/pull/348.