### PR TITLE
Fix IAM syntax error

### DIFF
--- a/cidc_api/shared/gcloud_client.py
+++ b/cidc_api/shared/gcloud_client.py
@@ -152,8 +152,6 @@ def create_intake_bucket(user_email: str) -> storage.Bucket:
     Grant the user GCS object admin permissions on the bucket, or refresh those
     permissions if they've already been granted.
     """
-    print("HELLO!", storage)
-
     storage_client = _get_storage_client()
     bucket_name = get_intake_bucket_name(user_email)
     bucket = storage_client.bucket(bucket_name)

--- a/cidc_api/shared/gcloud_client.py
+++ b/cidc_api/shared/gcloud_client.py
@@ -323,7 +323,7 @@ def _build_binding_with_expiry(
     condition = f'request.time < timestamp("{expiry_date.isoformat()}T00:00:00Z")'
     # Add an object URL prefix to the condition if a prefix was specified
     if prefix:
-        condition += f'&& resource.name.startsWith("projects/_/buckets/{bucket}/objects/{prefix}")&&'
+        condition += f' && resource.name.startsWith("projects/_/buckets/{bucket}/objects/{prefix}")'
 
     return {
         "role": role,

--- a/tests/shared/test_gcloud_client.py
+++ b/tests/shared/test_gcloud_client.py
@@ -159,6 +159,8 @@ def test_grant_download_access(monkeypatch):
         assert f"{GOOGLE_DOWNLOAD_ROLE} access on 10021/wes until" in condition["title"]
         assert "updated by the CIDC API" in condition["description"]
         assert "10021/wes" in condition["expression"]
+        # should have structure "<expiry time> && <prefix condition>""
+        assert len(condition["expression"].split(" && ")) == 2
 
     _mock_gcloud_storage([], set_iam_policy, monkeypatch)
     grant_download_access(EMAIL, "10021", "wes_analysis")


### PR DESCRIPTION
#381 introduced a bug in producing conditional IAM statements that was leading to 500 errors from the GCP IAM API on staging.

This PR fixes that bug, and adds a test to enforce the fix.