### PR TITLE
Use storage_client.bucket instead of .get_bucket

### DIFF
--- a/cidc_api/shared/gcloud_client.py
+++ b/cidc_api/shared/gcloud_client.py
@@ -47,7 +47,7 @@ def _get_storage_client() -> storage.Client:
 def _get_bucket(bucket_name: str) -> storage.Bucket:
     """Get the bucket with name `bucket_name` from GCS."""
     storage_client = _get_storage_client()
-    bucket = storage_client.get_bucket(bucket_name)
+    bucket = storage_client.bucket(bucket_name)
     return bucket
 
 


### PR DESCRIPTION
For a GCS client instance called `storage_client`, `storage_client.get_bucket(bucket_name)` throws a 404 error if `some_bucket` doesn't exist. This was leading to 500s when trying to re-enable users with no associated intake buckets.

`storage_client.bucket(bucket_name)` doesn't throw a 404 if `some_bucket` doesn't exist, so using this method instead clears up the 404 errors. It's up to callers of the `_get_bucket` helper method to ensure that the returned bucket exists using the `bucket.exists()` method.