### PR TITLE
Double the request timeout limit

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -7,6 +7,6 @@ is_dev = os.environ.get("ENV") == "dev"
 port = os.environ.get("PORT", 8080)
 loglevel = "DEBUG" if is_dev else "INFO"
 reload = is_dev
-timeout = 60
+timeout = 120
 # Send all logs to stdout (where App Engine reads them from)
 errorlog = "-"


### PR DESCRIPTION
For large manifests, we seem to be exceeding the 60 second timeout right now. There's definitely a need for us to profile that issue, but for now, just allow requests to take a longer time.