### PR TITLE
Add new 'network-viewer' role to RBAC

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -415,8 +415,12 @@ class Permissions(CommonColumns):
                 orig=f"`granted_by_user` user must exist, but no user found with id {self.granted_by_user}",
             )
 
+        is_network_viewer = grantee.role == CIDCRole.NETWORK_VIEWER.value
+
         # A user can only have 20 granular permissions at a time, due to GCS constraints
-        if (
+        # (with the exception of Network Viewers, who can't download data from GCS and aren't
+        # subject to this constraint.)
+        if not is_network_viewer and (
             len(Permissions.find_for_user(self.granted_to_user))
             >= GOOGLE_MAX_DOWNLOAD_PERMISSIONS
         ):
@@ -432,6 +436,10 @@ class Permissions(CommonColumns):
 
         # Always commit, because we don't want to grant IAM download unless this insert succeeds.
         super().insert(session=session, commit=True, compute_etag=compute_etag)
+
+        # Don't make an GCS changes if this user doesn't have download access
+        if is_network_viewer:
+            return
 
         try:
             # Grant IAM permission in GCS only if db insert worked
@@ -462,13 +470,15 @@ class Permissions(CommonColumns):
         if deleted_by_user is None:
             raise NoResultFound(f"no user with id {deleted_by}")
 
-        try:
-            # Revoke IAM permission in GCS
-            revoke_download_access(grantee.email, self.trial_id, self.upload_type)
-        except Exception as e:
-            raise IAMException(
-                "IAM revoke failed, and permission db record not removed."
-            ) from e
+        # Only make GCS IAM changes if this user has download access
+        if grantee.role != CIDCRole.NETWORK_VIEWER.value:
+            try:
+                # Revoke IAM permission in GCS
+                revoke_download_access(grantee.email, self.trial_id, self.upload_type)
+            except Exception as e:
+                raise IAMException(
+                    "IAM revoke failed, and permission db record not removed."
+                ) from e
 
         logger.info(
             f"admin-action: {deleted_by_user.email} removed from {grantee.email} the permission {self.upload_type} on {self.trial_id}"
@@ -500,6 +510,10 @@ class Permissions(CommonColumns):
         Grant each of the given `user`'s IAM permissions. If the permissions
         have already been granted, calling this will extend their expiry date.
         """
+        # Don't make an GCS changes if this user doesn't have download access
+        if user.role == CIDCRole.NETWORK_VIEWER.value:
+            return
+
         filter_for_user = lambda q: q.filter(Permissions.granted_to_user == user.id)
         perms = Permissions.list(
             page_size=Permissions.count(session=session, filter_=filter_for_user),

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -252,6 +252,7 @@ class CIDCRole(EnumBaseClass):
     DEVELOPER = "developer"
     DEVOPS = "devops"
     NCI_BIOBANK_USER = "nci-biobank-user"
+    NETWORK_VIEWER = "network-viewer"
 
 
 ROLES = [role.value for role in CIDCRole]

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -437,7 +437,7 @@ class Permissions(CommonColumns):
         # Always commit, because we don't want to grant IAM download unless this insert succeeds.
         super().insert(session=session, commit=True, compute_etag=compute_etag)
 
-        # Don't make an GCS changes if this user doesn't have download access
+        # Don't make any GCS changes if this user doesn't have download access
         if is_network_viewer:
             return
 
@@ -510,7 +510,7 @@ class Permissions(CommonColumns):
         Grant each of the given `user`'s IAM permissions. If the permissions
         have already been granted, calling this will extend their expiry date.
         """
-        # Don't make an GCS changes if this user doesn't have download access
+        # Don't make any GCS changes if this user doesn't have download access
         if user.role == CIDCRole.NETWORK_VIEWER.value:
             return
 

--- a/cidc_api/resources/downloadable_files.py
+++ b/cidc_api/resources/downloadable_files.py
@@ -1,3 +1,4 @@
+from cidc_api.models.models import CIDCRole
 from io import BytesIO
 from typing import List
 
@@ -12,6 +13,7 @@ from ..models import (
     DownloadableFileSchema,
     DownloadableFileListSchema,
     Permissions,
+    ROLES,
 )
 from ..shared import gcloud_client
 from ..shared.auth import get_current_user, requires_auth
@@ -125,7 +127,10 @@ def generate_filelist(args):
 
 
 @downloadable_files_bp.route("/download_url", methods=["GET"])
-@requires_auth("download_url")
+@requires_auth(
+    "download_url",
+    allowed_roles=[role for role in ROLES if role != CIDCRole.NETWORK_VIEWER.value],
+)
 @use_args({"id": fields.Str(required=True)}, location="query")
 def get_download_url(args):
     """

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,5 +1,6 @@
 """Configuration for the gunicorn WSGI server."""
 import os
+from gunicorn.arbiter import Arbiter
 
 is_dev = os.environ.get("ENV") == "dev"
 

--- a/migrations/versions/509970372467_add_network_viewer_rbac_role.py
+++ b/migrations/versions/509970372467_add_network_viewer_rbac_role.py
@@ -1,0 +1,60 @@
+"""Add network-viewer RBAC role
+
+Revision ID: 509970372467
+Revises: e4089581a8ec
+Create Date: 2021-03-10 16:06:25.997472
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "509970372467"
+down_revision = "e4089581a8ec"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Recreate the roles enum with 'network-viewer' added as a value
+    conn.execute("ALTER TABLE users ALTER role TYPE TEXT")
+    conn.execute("DROP TYPE roles")
+    conn.execute(
+        """CREATE TYPE roles AS ENUM(
+            'cidc-admin',
+            'cidc-biofx-user',
+            'cimac-biofx-user',
+            'cimac-user',
+            'developer',
+            'devops',
+            'nci-biobank-user',
+            'network-viewer'
+        )"""
+    )
+    conn.execute("ALTER TABLE users ALTER role TYPE roles USING role::roles")
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    # Clear roles for users who are 'network-viewer's
+    conn.execute("UPDATE users SET role = null WHERE role = 'network-viewer'")
+
+    # Recreate the roles enum without 'network-viewer' as a value
+    conn.execute("ALTER TABLE users ALTER role TYPE TEXT")
+    conn.execute("DROP TYPE roles")
+    conn.execute(
+        """CREATE TYPE roles AS ENUM(
+            'cidc-admin',
+            'cidc-biofx-user',
+            'cimac-biofx-user',
+            'cimac-user',
+            'developer',
+            'devops',
+            'nci-biobank-user'
+        )"""
+    )
+    conn.execute("ALTER TABLE users ALTER role TYPE roles USING role::roles")

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         "cidc_api.models.files",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.24.3",
+    version="0.24.4",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         "cidc_api.models.files",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.24.4",
+    version="0.24.5",
     zip_safe=False,
 )

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -387,6 +387,11 @@ def test_get_download_url(cidc_api, clean_db, monkeypatch):
     assert res.status_code == 200
     assert res.json == test_url
 
+    # network viewers aren't allowed to get download urls
+    make_role(user_id, CIDCRole.NETWORK_VIEWER.value, cidc_api)
+    res = client.get(f"/downloadable_files/download_url?id={file_id}")
+    assert res.status_code == 401
+
 
 def test_log_multiple_errors(caplog):
     """Check that the log_multiple_errors function doesn't throw an error itself."""


### PR DESCRIPTION
`network-viewer`s can list metadata / what files are available for trials and assays that they have permission to view. However, they are not given permission to download any files from GCS.