### PR TITLE
Add data access report generation to the Users model

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -439,6 +439,7 @@ def test_endpoint_urls(cidc_api):
         "/users/",
         "/users/self",
         "/users/<int:user>",
+        "/users/data_access_report",
     }
 
     # Check that every endpoint included in the API is expected.


### PR DESCRIPTION
This PR adds functionality to create an automatic spreadsheet report on what users have access to what data types on what trials, leaning on pandas [`ExcelWriter`](https://pandas.pydata.org/docs/reference/api/pandas.ExcelWriter.html) feature.

Currently working on a UI PR to add a button for triggering/downloading these reports from the portal admin page.