### PR TITLE
Add method and API endpoint for summarizing data ingested for each trial

### DIFF
--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -27,8 +27,6 @@ assert ENV == "dev" if DEBUG else True, "DEBUG mode is only allowed when ENV='de
 TESTING = environ.get("TESTING") == "True"
 ALLOWED_CLIENT_URL = environ.get("ALLOWED_CLIENT_URL")
 IS_GUNICORN = "gunicorn" in environ.get("SERVER_SOFTWARE", "")
-# DO NOT CHANGE - used only for mocking in tests that need to bypass this feature
-DISABLE_METADATA_VALIDATION_ON_INSERT = False
 
 ### Configure miscellaneous constants ###
 TEMPLATES_DIR = path.join("/tmp", "templates")

--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -27,6 +27,8 @@ assert ENV == "dev" if DEBUG else True, "DEBUG mode is only allowed when ENV='de
 TESTING = environ.get("TESTING") == "True"
 ALLOWED_CLIENT_URL = environ.get("ALLOWED_CLIENT_URL")
 IS_GUNICORN = "gunicorn" in environ.get("SERVER_SOFTWARE", "")
+# DO NOT CHANGE - used only for mocking in tests that need to bypass this feature
+DISABLE_METADATA_VALIDATION_ON_INSERT = False
 
 ### Configure miscellaneous constants ###
 TEMPLATES_DIR = path.join("/tmp", "templates")

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -63,7 +63,6 @@ from ..config.settings import (
     TESTING,
     INACTIVE_USER_DAYS,
     GOOGLE_MAX_DOWNLOAD_PERMISSIONS,
-    DISABLE_METADATA_VALIDATION_ON_INSERT,
 )
 from ..shared import emails
 from ..shared.gcloud_client import (
@@ -631,8 +630,10 @@ class TrialMetadata(CommonColumns):
 
     @validates("metadata_json")
     def validate_metadata_json(self, key, metadata_json):
-        if DISABLE_METADATA_VALIDATION_ON_INSERT:
-            return metadata_json
+        return self._validate_metadata_json(metadata_json)
+
+    @staticmethod
+    def _validate_metadata_json(metadata_json):
         errs = trial_metadata_validator.iter_error_messages(metadata_json)
         messages = list(f"'metadata_json': {err}" for err in errs)
         if messages:

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -63,6 +63,7 @@ from ..config.settings import (
     TESTING,
     INACTIVE_USER_DAYS,
     GOOGLE_MAX_DOWNLOAD_PERMISSIONS,
+    DISABLE_METADATA_VALIDATION_ON_INSERT,
 )
 from ..shared import emails
 from ..shared.gcloud_client import (
@@ -630,6 +631,8 @@ class TrialMetadata(CommonColumns):
 
     @validates("metadata_json")
     def validate_metadata_json(self, key, metadata_json):
+        if DISABLE_METADATA_VALIDATION_ON_INSERT:
+            return metadata_json
         errs = trial_metadata_validator.iter_error_messages(metadata_json)
         messages = list(f"'metadata_json': {err}" for err in errs)
         if messages:
@@ -858,6 +861,109 @@ class TrialMetadata(CommonColumns):
             "num_participants": num_participants,
             "num_samples": num_samples,
         }
+
+    @staticmethod
+    @with_default_session
+    def get_summaries(session: Session) -> List[dict]:
+        """
+        Return a list of trial summaries, where each summary has structure like:
+        ```python
+            {
+                "trial_id": ...,
+                "file_size_bytes": ..., # total file size for the trial
+                "wes": ..., # wes sample count
+                "cytof": ..., # cytof sample count
+                ... # other assays
+            }
+        ```
+        NOTE: if the metadata model for any existing assays substantially changes,
+        or if new assays are introduced that don't follow the typical structure 
+        (batches containing sample-level records), then this method will need to
+        be updated to accommodate those changes.
+        """
+        # Compute the total amount of data in bytes stored for each trial
+        files_subquery = """
+            select
+                trial_id,
+                'file_size_bytes' as key,
+                sum(file_size_bytes) as value
+            from
+                downloadable_files
+            group by trial_id
+        """
+
+        # Compute the number of samples associated with each assay type for
+        # assays whose metadata follows the typical structure: an array of batches,
+        # with each batch containing an array of records, where each record
+        # corresponds to a unique sample.
+        generic_assay_subquery = """
+            select
+                trial_id,
+                key as key,
+                sum(jsonb_array_length(batches->'records')) as value
+            from
+                trial_metadata,
+                jsonb_each(metadata_json->'assays') assays,
+                jsonb_array_elements(value) batches
+            where key not in ('olink', 'nanostring')
+            group by trial_id, key
+        """
+
+        # Compute the number of samples associated with nanostring uploads.
+        # Nanostring metadata has a slightly different structure than typical
+        # assays, where each batch has an array of runs, and each run has
+        # an array of sample-level entries.
+        nanostring_subquery = """
+            select
+                trial_id,
+                'nanostring' as key,
+                sum(jsonb_array_length(runs->'samples')) as value
+            from
+                trial_metadata,
+                jsonb_array_elements(metadata_json#>'{assays,nanostring}') batches,
+                jsonb_array_elements(batches->'runs') runs
+            group by trial_id
+        """
+
+        # Compute the number of samples associated with olink uploads.
+
+        olink_subquery = """
+            select
+                trial_id,
+                'olink' as key,
+                sum((records#>'{files,assay_npx,number_of_samples}')::text::integer) as value
+            from
+                trial_metadata,
+                jsonb_array_elements(metadata_json#>'{assays,olink,batches}') batches,
+                jsonb_array_elements(batches->'records') records
+            group by trial_id
+        """
+
+        # All the subqueries produce the same set of columns, so `UNION`
+        # them together into a single query, aggregating results into
+        # trial-level JSON dictionaries with the shape described in the docstring.
+        combined_query = f"""
+            select
+                jsonb_object_agg(key, value) || jsonb_object_agg('trial_id', trial_id)
+            from (
+                {files_subquery}
+                union
+                {generic_assay_subquery}
+                union
+                {nanostring_subquery}
+                union
+                {olink_subquery}
+            ) q
+            group by trial_id;
+        """
+
+        # Run the query and extract the trial-level summary dictionaries
+        summaries = [summary for (summary,) in session.execute(combined_query)]
+
+        # Shortcut to impute 0 values for assays where trials don't yet have data
+        summaries = pd.DataFrame(summaries).fillna(0).to_dict("records")
+
+        return summaries
 
 
 class UploadJobStatus(EnumBaseClass):

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -926,7 +926,12 @@ class TrialMetadata(CommonColumns):
         """
 
         # Compute the number of samples associated with olink uploads.
-
+        # Unlike other assays, olink metadata is an object at the top level
+        # rather than an array of batches. This object has a "batches"
+        # property that points to an array of batches, and each batch contains
+        # an array of records. These records are *not* sample-level; rather,
+        # the number of samples corresponding to a given record is stored
+        # like: record["files"]["assay_npx"]["number_of_samples"].
         olink_subquery = """
             select
                 trial_id,

--- a/cidc_api/resources/trial_metadata.py
+++ b/cidc_api/resources/trial_metadata.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify
 from webargs import fields
 from werkzeug.exceptions import BadRequest
 
@@ -65,6 +65,13 @@ def create_trial_metadata(trial):
         raise BadRequest(str(e.orig))
 
     return trial
+
+
+@trial_metadata_bp.route("/summaries", methods=["GET"])
+@requires_auth("trial_metadata_summaries", trial_modifier_roles)
+def get_trial_metadata_summaries():
+    """Get summaries of all trial metadata in the database"""
+    return jsonify(TrialMetadata.get_summaries())
 
 
 @trial_metadata_bp.route("/<string:trial>", methods=["GET"])

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -367,6 +367,84 @@ def test_partial_patch_trial_metadata(clean_db):
 
 
 @db_test
+def test_trial_metadata_get_summaries(clean_db, monkeypatch):
+    """Check that trial data summaries are computed as expected"""
+    monkeypatch.setattr(
+        "cidc_api.models.models.DISABLE_METADATA_VALIDATION_ON_INSERT", True
+    )
+
+    # Add some trials
+    records = [{"fake": "record"}]
+    tm1 = {
+        **METADATA,
+        "protocol_identifier": "tm1",
+        "assays": {
+            "wes": [{"records": records * 3}],
+            "rna": [{"records": records * 2}],
+            "nanostring": [
+                {"runs": [{"samples": records * 2}]},
+                {"runs": [{"samples": records * 1}]},
+            ],
+        },
+    }
+    tm2 = {
+        **METADATA,
+        "protocol_identifier": "tm1",
+        "assays": {
+            "cytof": [{"records": records * 4}],
+            "olink": {
+                "batches": [
+                    {"records": [{"number_of_samples": 2}, {"number_of_samples": 3}]},
+                    {"records": [{"number_of_samples": 5}]},
+                ]
+            },
+        },
+    }
+    TrialMetadata(trial_id="tm1", metadata_json=tm1).insert()
+    TrialMetadata(trial_id="tm2", metadata_json=tm2).insert()
+
+    # Add some files
+    for i, (tid, fs) in enumerate([("tm1", 3), ("tm1", 2), ("tm2", 4), ("tm2", 6)]):
+        DownloadableFiles(
+            trial_id=tid,
+            file_size_bytes=fs,
+            object_url=str(i),
+            facet_group="",
+            uploaded_timestamp=datetime.now(),
+            file_name="",
+            data_format="",
+            upload_type="",
+        ).insert()
+
+    sorter = lambda s: s["trial_id"]
+    received = sorted(TrialMetadata.get_summaries(), key=sorter)
+    expected = sorted(
+        [
+            {
+                "cytof": 4.0,
+                "olink": 0.0,
+                "trial_id": "tm2",
+                "file_size_bytes": 10,
+                "rna": 0.0,
+                "wes": 0.0,
+                "nanostring": 0.0,
+            },
+            {
+                "cytof": 0.0,
+                "olink": 0.0,
+                "trial_id": "tm1",
+                "file_size_bytes": 5,
+                "rna": 2.0,
+                "wes": 3.0,
+                "nanostring": 3.0,
+            },
+        ],
+        key=sorter,
+    )
+    assert received == expected
+
+
+@db_test
 def test_create_assay_upload(clean_db):
     """Try to create an assay upload"""
     new_user = Users.create(PROFILE)
@@ -1101,4 +1179,4 @@ def test_user_get_data_access_report(clean_db, monkeypatch):
         if user == admin_user:
             assert set(["*"]) == set(user_df.permissions)
         else:
-            assert set(["wes,cytof"]) == set(user_df.permissions)
+            assert set(user_df.permissions) - set(["wes,cytof", "cytof,wes"]) == set()

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -1,3 +1,4 @@
+from cidc_api.models.schemas import TrialMetadataListSchema
 import io
 import logging
 from copy import deepcopy
@@ -370,13 +371,14 @@ def test_partial_patch_trial_metadata(clean_db):
 def test_trial_metadata_get_summaries(clean_db, monkeypatch):
     """Check that trial data summaries are computed as expected"""
     monkeypatch.setattr(
-        "cidc_api.models.models.DISABLE_METADATA_VALIDATION_ON_INSERT", True
+        TrialMetadata, "_validate_metadata_json", staticmethod(lambda m: m)
     )
 
     # Add some trials
     records = [{"fake": "record"}]
     tm1 = {
         **METADATA,
+        # deliberately override METADATA['protocol_identifier']
         "protocol_identifier": "tm1",
         "assays": {
             "wes": [{"records": records * 3}],
@@ -389,6 +391,7 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
     }
     tm2 = {
         **METADATA,
+        # deliberately override METADATA['protocol_identifier']
         "protocol_identifier": "tm1",
         "assays": {
             "cytof": [{"records": records * 4}],

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -1182,4 +1182,4 @@ def test_user_get_data_access_report(clean_db, monkeypatch):
         if user == admin_user:
             assert set(["*"]) == set(user_df.permissions)
         else:
-            assert set(user_df.permissions) - set(["wes,cytof", "cytof,wes"]) == set()
+            assert set(user_df.permissions).issubset(["wes,cytof", "cytof,wes"])

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -325,7 +325,7 @@ def test_get_trial_metadata_summaries(cidc_api, clean_db, monkeypatch):
     user_id = setup_user(cidc_api, monkeypatch)
 
     monkeypatch.setattr(
-        "cidc_api.models.models.DISABLE_METADATA_VALIDATION_ON_INSERT", True
+        TrialMetadata, "_validate_metadata_json", staticmethod(lambda m: m)
     )
 
     result = {"some": "json"}

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock
 from datetime import datetime
 from typing import Tuple
 
@@ -9,6 +10,7 @@ from cidc_api.models import (
     Permissions,
     CIDCRole,
     DownloadableFiles,
+    ROLES,
 )
 
 from ..utils import mock_current_user, make_role, mock_gcloud_client
@@ -316,3 +318,30 @@ def test_update_trial(cidc_api, clean_db, monkeypatch):
 
         with cidc_api.app_context():
             trial = TrialMetadata.find_by_id(trial.id)
+
+
+def test_get_trial_metadata_summaries(cidc_api, clean_db, monkeypatch):
+    """Check that the /trial_metadata/summaries endpoint behaves as expected"""
+    user_id = setup_user(cidc_api, monkeypatch)
+
+    monkeypatch.setattr(
+        "cidc_api.models.models.DISABLE_METADATA_VALIDATION_ON_INSERT", True
+    )
+
+    result = {"some": "json"}
+    TrialMetadataMock = MagicMock()
+    TrialMetadataMock.get_summaries.return_value = result
+    monkeypatch.setattr(
+        "cidc_api.resources.trial_metadata.TrialMetadata", TrialMetadataMock
+    )
+
+    client = cidc_api.test_client()
+
+    for role in ROLES:
+        make_role(user_id, role, cidc_api)
+        res = client.get("/trial_metadata/summaries")
+        if role in trial_modifier_roles:
+            assert res.status_code == 200
+            assert res.json == result
+        else:
+            assert res.status_code == 401

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -433,6 +433,7 @@ def test_endpoint_urls(cidc_api):
         "/permissions/",
         "/permissions/<int:permission>",
         "/trial_metadata/",
+        "/trial_metadata/summaries",
         "/trial_metadata/<string:trial>",
         "/upload_jobs/",
         "/upload_jobs/<int:upload_job>",


### PR DESCRIPTION
This PR adds the `/trial_metadata/summaries` endpoint, which returns total file size and assay-sample counts for each trial in the database.