### PR TITLE
Update TrialMetadata.list to prune raw metadata

### DIFF
--- a/cidc_api/models/schemas.py
+++ b/cidc_api/models/schemas.py
@@ -93,6 +93,8 @@ class TrialMetadataSchema(BaseSchema):
         model = TrialMetadata
 
     file_bundle = fields.Dict(dump_only=True)
+    num_participants = fields.Int(dump_only=True)
+    num_samples = fields.Int(dump_only=True)
 
 
 TrialMetadataListSchema = _make_list_schema(TrialMetadataSchema())

--- a/cidc_api/resources/trial_metadata.py
+++ b/cidc_api/resources/trial_metadata.py
@@ -27,8 +27,10 @@ trial_modifier_roles = [CIDCRole.ADMIN.value, CIDCRole.NCI_BIOBANK_USER.value]
 
 
 bundle_argname = "include_file_bundles"
+counts_argname = "include_counts"
 trial_filter_schema = {
     bundle_argname: fields.Bool(),
+    counts_argname: fields.Bool(),
     "trial_ids": fields.DelimitedList(fields.Str),
 }
 
@@ -40,14 +42,12 @@ trial_filter_schema = {
 def list_trial_metadata(args, pagination_args):
     """List all trial metadata records."""
     user = get_current_user()
-    include_file_bundles = args.pop(bundle_argname, False)
-    filter_ = TrialMetadata.build_trial_filter(user=user, **args)
-    if include_file_bundles:
-        trials = TrialMetadata.list_with_file_bundles(
-            filter_=filter_, **pagination_args
-        )
-    else:
-        trials = TrialMetadata.list(filter_=filter_, **pagination_args)
+    trials = TrialMetadata.list(
+        include_file_bundles=args.pop(bundle_argname, False),
+        include_counts=args.pop(counts_argname, False),
+        filter_=TrialMetadata.build_trial_filter(user=user, **args),
+        **pagination_args,
+    )
     count = TrialMetadata.count()
 
     return {"_items": trials, "_meta": {"total": count}}

--- a/query.sql
+++ b/query.sql
@@ -1,3 +1,0 @@
-SELECT trial_metadata._created AS trial_metadata__created, trial_metadata._updated AS trial_metadata__updated, trial_metadata._etag AS trial_metadata__etag, trial_metadata.id AS trial_metadata_id, trial_metadata.trial_id AS trial_metadata_trial_id, ((jsonb_set(trial_metadata.metadata_json, %(jsonb_set_1)s, '[]'::jsonb) - %(jsonb_set_2)s) - %(param_1)s) - %(param_2)s AS metadata_json 
-FROM trial_metadata 
- LIMIT %(param_3)s OFFSET %(param_4)s

--- a/query.sql
+++ b/query.sql
@@ -1,0 +1,3 @@
+SELECT trial_metadata._created AS trial_metadata__created, trial_metadata._updated AS trial_metadata__updated, trial_metadata._etag AS trial_metadata__etag, trial_metadata.id AS trial_metadata_id, trial_metadata.trial_id AS trial_metadata_trial_id, ((jsonb_set(trial_metadata.metadata_json, %(jsonb_set_1)s, '[]'::jsonb) - %(jsonb_set_2)s) - %(param_1)s) - %(param_2)s AS metadata_json 
+FROM trial_metadata 
+ LIMIT %(param_3)s OFFSET %(param_4)s


### PR DESCRIPTION
We've recently noted that the endpoint for listing trials, `GET /trial_metadata`, has been running very slowly. Local profiling suggests that we can speed up this trial listing operation by pruning unneeded branches of the raw trial metadata JSON. 

So, this PR updates `TrialMetadata.list` to issue a database query that does not load the `participants`, `assays`, `analysis`, and `shipments` branches of each trial's metadata blob, saving substantially on the amount of data this query loads.

Additionally, this PR adds a URL query param `include_counts` to the `GET /trial_metadata` endpoint which, when true, indicates to the API that it should include trial-level participant and sample counts for each trial (since the raw metadata JSON will no longer include the info required for API clients to compute this themselves). 

This should be merged *after* a corresponding UI PR that handles this new endpoint behavior.