### PR TITLE
Don't automatically validate TrialMetadata.metadata_json

### DIFF
--- a/cidc_api/models/migrations.py
+++ b/cidc_api/models/migrations.py
@@ -165,7 +165,7 @@ def _run_metadata_migration(
         migration = metadata_migration(trial.metadata_json)
 
         # Update the trial metadata object
-        trial.metadata_json = migration.result
+        trial.safely_set_metadata_json(migration.result)
 
         # A workaround fix for JSON field modifications not being tracked
         # by SQLalchemy for some reason. Using MutableDict.as_mutable(JSON)

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -810,9 +810,14 @@ class TrialMetadata(CommonColumns):
     num_participants: Optional[int]
     num_samples: Optional[int]
 
-    # List of metadata JSON fields that a) should not be sent to clients
-    # by TrialMetadata.list and b) should not accept updates via the API.
-    PROTECTED_FIELDS = ["participants", "assays", "analysis", "shipments"]
+    # List of metadata JSON fields that should not be sent to clients
+    # in queries that list trial metadata, because they may contain a lot
+    # of data.
+    PRUNED_FIELDS = ["participants", "assays", "analysis", "shipments"]
+
+    # List of metadata JSON fields that should only be settable via
+    # manifest and metadata templates.
+    PROTECTED_FIELDS = [*PRUNED_FIELDS, "protocol_identifier"]
 
     @classmethod
     def _pruned_metadata_json(cls):
@@ -821,7 +826,7 @@ class TrialMetadata(CommonColumns):
         "shipments", and "participants" properties removed.
         """
         query = cls.metadata_json
-        for field in cls.PROTECTED_FIELDS:
+        for field in cls.PRUNED_FIELDS:
             query = query.op("-")(field)
 
         return query.label("metadata_json")

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -810,19 +810,21 @@ class TrialMetadata(CommonColumns):
     num_participants: Optional[int]
     num_samples: Optional[int]
 
+    # List of metadata JSON fields that a) should not be sent to clients
+    # by TrialMetadata.list and b) should not accept updates via the API.
+    PROTECTED_FIELDS = ["participants", "assays", "analysis", "shipments"]
+
     @classmethod
     def _pruned_metadata_json(cls):
         """
         Builds a modified metadata_json column selector with the "assays", "analysis",
         "shipments", and "participants" properties removed.
         """
-        return (
-            cls.metadata_json.op("-")("participants")
-            .op("-")("assays")
-            .op("-")("analysis")
-            .op("-")("shipments")
-            .label("metadata_json")
-        )
+        query = cls.metadata_json
+        for field in cls.PROTECTED_FIELDS:
+            query = query.op("-")(field)
+
+        return query.label("metadata_json")
 
     @classmethod
     @with_default_session

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -935,29 +935,26 @@ class TrialMetadata(CommonColumns):
         compute_etag: bool = True,
         validate_metadata: bool = True,
     ):
-        """Add the current instance to the session. Validate metadata_json, if any, if validate_metadata=True."""
+        """Add the current instance to the session. Skip JSON metadata validation validate_metadata=False."""
         if self.metadata_json is not None and validate_metadata:
             self.validate_metadata_json(self.metadata_json)
 
         return super().insert(session=session, commit=commit, compute_etag=compute_etag)
 
     @with_default_session
-    def update(self, session: Session, changes: dict = None, commit: bool = True):
+    def update(
+        self,
+        session: Session,
+        changes: dict = None,
+        commit: bool = True,
+        validate_metadata: bool = True,
+    ):
         """
         Update the current TrialMetadata instance if it exists. `changes` should be
-        a dictionary mapping column names to updated values.
-
-        NOTE: if `changes` contains a metadata_json update, only values with provided keys
-        will be updated - e.g., an update that looks like {'nct_id': 'foo'} will update
-        only the 'nct_id' key in the `metadata_json` blob, not overwrite the entire blob.
-        This only works for top-level keys, not nested keys like sample-level metadata.
+        a dictionary mapping column names to updated values. Skip JSON metadata validation 
+        validate_metadata=False.
         """
-        # Do what's described in the docstring note
-        if "metadata_json" in changes:
-            changes["metadata_json"] = {
-                **self.metadata_json,
-                **changes["metadata_json"],
-            }
+        if "metadata_json" in changes and validate_metadata:
             self.validate_metadata_json(changes["metadata_json"])
 
         return super().update(session=session, changes=changes, commit=commit)

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -748,7 +748,6 @@ class TrialMetadata(CommonColumns):
 
         logger.info(f"Creating new trial metadata with id {trial_id}")
         trial = TrialMetadata(trial_id=trial_id)
-        trial.safely_set_metadata_json(metadata_json)
         trial.insert(session=session, commit=commit)
 
         return trial

--- a/cidc_api/resources/trial_metadata.py
+++ b/cidc_api/resources/trial_metadata.py
@@ -60,7 +60,8 @@ def list_trial_metadata(args, pagination_args):
 def create_trial_metadata(trial):
     """Create a new trial metadata record."""
     try:
-        trial.insert()
+        # metadata was already validated by unmarshal_request
+        trial.insert(validate_metadata=False)
     except IntegrityError as e:
         raise BadRequest(str(e.orig))
 

--- a/cidc_api/resources/trial_metadata.py
+++ b/cidc_api/resources/trial_metadata.py
@@ -93,6 +93,15 @@ def get_trial_metadata_by_trial_id(trial):
 @marshal_response(trial_metadata_schema, 200)
 def update_trial_metadata_by_trial_id(trial, trial_updates):
     """Update an existing trial metadata record by trial_id."""
+    # Block updates to protected metadata JSON fields
+    metadata_updates = trial_updates.get("metadata_json")
+    if trial.metadata_json or metadata_updates:
+        for field in TrialMetadata.PROTECTED_FIELDS:
+            if trial.metadata_json.get(field) != metadata_updates.get(field):
+                raise BadRequest(
+                    f"updating metadata_json['{field}'] via the API is prohibited"
+                )
+
     trial.update(changes=trial_updates)
 
     return trial

--- a/cidc_api/shared/rest_utils.py
+++ b/cidc_api/shared/rest_utils.py
@@ -46,6 +46,8 @@ def unmarshal_request(schema: BaseSchema, kwarg_name: str, load_sqla: bool = Tru
                 loaded_instance = schema.load(request.json)
                 if load_sqla:
                     body = loaded_instance
+                # Run any model-defined field validations
+                loaded_instance.validate()
             except ValidationError as e:
                 raise UnprocessableEntity(e.messages)
             except ValidationMultiError as e:

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         "cidc_api.models.files",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.24.15",
+    version="0.24.16",
     zip_safe=False,
 )

--- a/tests/models/test_migrations.py
+++ b/tests/models/test_migrations.py
@@ -142,7 +142,7 @@ def test_migrations_failures(use_upload_jobs_table, monkeypatch):
     select_assay_uploads.side_effect = None
     run_metadata_migration(mock_migration, use_upload_jobs_table)
     # Ensure we updated trials as expected
-    assert trial_record.metadata_json == new_metadata
+    trial_record.safely_set_metadata_json.assert_called_with(new_metadata)
     # Ensure we updated files as expected
     assert df_record.object_url == "b_new_url"
     assert df_record.additional_metadata == {"some_assay.extra": "metadata"}

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -370,10 +370,6 @@ def test_partial_patch_trial_metadata(clean_db):
 @db_test
 def test_trial_metadata_get_summaries(clean_db, monkeypatch):
     """Check that trial data summaries are computed as expected"""
-    monkeypatch.setattr(
-        TrialMetadata, "_validate_metadata_json", staticmethod(lambda m: m)
-    )
-
     # Add some trials
     records = [{"fake": "record"}]
     tm1 = {
@@ -408,8 +404,8 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
             },
         },
     }
-    TrialMetadata(trial_id="tm1", metadata_json=tm1).insert()
-    TrialMetadata(trial_id="tm2", metadata_json=tm2).insert()
+    TrialMetadata(trial_id="tm1", metadata_json=tm1).insert(validate_metadata=False)
+    TrialMetadata(trial_id="tm2", metadata_json=tm2).insert(validate_metadata=False)
 
     # Add some files
     for i, (tid, fs) in enumerate([("tm1", 3), ("tm1", 2), ("tm2", 4), ("tm2", 6)]):

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -1,3 +1,4 @@
+from jsonschema.validators import validate
 from cidc_api.models.schemas import TrialMetadataListSchema
 import io
 import logging
@@ -299,6 +300,53 @@ def test_create_trial_metadata(clean_db):
 
     with pytest.raises(ValidationMultiError, match="'buzz' was unexpected"):
         TrialMetadata(trial_id="foo", metadata_json={"buzz": "bazz"}).insert()
+
+
+@db_test
+def test_trial_metadata_insert(clean_db):
+    """Test that metadata validation on insert works as expected"""
+    # No error with valid metadata
+    trial = TrialMetadata(trial_id=TRIAL_ID, metadata_json=METADATA)
+    trial.insert()
+
+    # Error with invalid metadata
+    trial.metadata_json = {"foo": "bar"}
+    with pytest.raises(ValidationMultiError):
+        trial.insert()
+
+    # No error if validate_metadata=False
+    trial.insert(validate_metadata=False)
+
+
+@db_test
+def test_trial_metadata_update(clean_db):
+    """Test that metadata validation on update works as expected"""
+    trial = TrialMetadata(trial_id=TRIAL_ID, metadata_json=METADATA)
+    trial.insert()
+
+    # No error on valid `changes` update
+    trial.update(changes={"metadata_json": {**METADATA, "nct_id": "foo"}})
+
+    # No error on valid attribute update
+    trial.metadata_json = {**METADATA, "nct_id": "bar"}
+    trial.update()
+
+    bad_json = {"metadata_json": {"foo": "bar"}}
+
+    # Error on invalid `changes` update
+    with pytest.raises(ValidationMultiError):
+        trial.update(changes=bad_json)
+
+    # No error on invalid `changes` update if validate_metadata=False
+    trial.update(changes=bad_json, validate_metadata=False)
+
+    # Error on invalid attribute update
+    trial.metadata_json = bad_json
+    with pytest.raises(ValidationMultiError):
+        trial.update()
+
+    # No error on invalid attribute update if validate_metadata=False
+    trial.update(validate_metadata=False)
 
 
 @db_test

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -342,6 +342,8 @@ def test_update_trial(cidc_api, clean_db, monkeypatch):
             metadata = trial.metadata_json.copy()
             if field == "participants":
                 metadata["participants"] = []
+            elif field == "protocol_identifier":
+                metadata["protocol_identifier"] = "uh oh!"
             else:
                 metadata.pop(field)
             res = client.patch(

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -191,7 +191,7 @@ def test_list_trials(cidc_api, clean_db, monkeypatch):
     res = client.get("/trial_metadata")
     assert res.status_code == 200
     metadata_json = res.json["_items"][0]["metadata_json"]
-    assert metadata_json["participants"] == []
+    assert metadata_json.get("participants") is None
     assert metadata_json.get("assays") is None
     assert metadata_json.get("analysis") is None
     assert metadata_json.get("shipments") is None
@@ -363,10 +363,6 @@ def test_update_trial(cidc_api, clean_db, monkeypatch):
 def test_get_trial_metadata_summaries(cidc_api, clean_db, monkeypatch):
     """Check that the /trial_metadata/summaries endpoint behaves as expected"""
     user_id = setup_user(cidc_api, monkeypatch)
-
-    monkeypatch.setattr(
-        TrialMetadata, "_validate_metadata_json", staticmethod(lambda m: m)
-    )
 
     result = {"some": "json"}
     TrialMetadataMock = MagicMock()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@
 This file doesn't contain tests for methods that don't directly correspond
 to data resources, like endpoints that handle upload-related functionality.
 """
+from copy import deepcopy
 from unittest.mock import MagicMock
 from datetime import datetime
 from dateutil.parser import parse as parse_date
@@ -262,7 +263,14 @@ def test_resource_and_item_get(resource, config, cidc_api, clean_db, monkeypatch
     if "GET" in config["allowed_methods"]:
         assert response.status_code == 200
         item = response.json["_items"][0]
-        assert_dict_contains(item, config["json"])
+        # trial_metadata is an exception - it prunes metadata_json
+        # on resource-level GET queries
+        if resource == "trial_metadata":
+            json = deepcopy(config["json"])
+            json["metadata_json"].pop("participants")
+            assert_dict_contains(item, json)
+        else:
+            assert_dict_contains(item, config["json"])
         if config.get("pagination"):
             assert response.json["_meta"]["total"] == 3
         elif resource == "users":


### PR DESCRIPTION
This PR does three things:
1. Removes the automatic `TrialMetadata.metadata_json` JSON schema validator and updates related code. Doing so leads to a further performance improvement on top of #439 on the query `GET /trial_metadata?include_file_bundles=true&include_counts=true`:
```
N=10

PR #439:
  Slowest:      2.8991 secs
  Fastest:      2.1856 secs
  Average:      2.3740 secs
  Requests/sec: 0.4212

This PR:
  Slowest:      1.4725 secs
  Fastest:      1.0507 secs
  Average:      1.2079 secs
  Requests/sec: 0.8279
```
2. Fully prunes the `metadata_json["participants"]` property when sending a list of trials to a client (in #439, it was set to `[]` to appease the automatic schema validator, but this amounts to returning inaccurate data). This change will fix a bug that caused updates to trial metadata made on the portal's admin page to clear all participant/sample data for the trial being updated.
