### PR TITLE
Only use `union all` in TrialMetadata.get_summaries query

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -1169,7 +1169,7 @@ class TrialMetadata(CommonColumns):
                 jsonb_array_elements(batches->'participants') participant
         """
 
-        # All the subqueries produce the same set of columns, so `UNION`
+        # All the subqueries produce the same set of columns, so `UNION ALL`
         # them together into a single query, aggregating results into
         # trial-level JSON dictionaries with the shape described in the docstring.
         combined_query = f"""
@@ -1182,19 +1182,19 @@ class TrialMetadata(CommonColumns):
                     sum(value) as value
                 from (
                     {participants_subquery}
-                    union
+                    union all
                     {samples_subquery}
-                    union
+                    union all
                     {files_subquery}
-                    union
+                    union all
                     {clinical_subquery}
-                    union
+                    union all
                     {generic_assay_subquery}
-                    union
+                    union all
                     {nanostring_subquery}
-                    union
+                    union all
                     {olink_subquery}
-                    union
+                    union all
                     {elisa_subquery}
                     union all
                     {cytof_e4412_subquery}

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -1169,9 +1169,11 @@ class TrialMetadata(CommonColumns):
                 jsonb_array_elements(batches->'participants') participant
         """
 
-        # All the subqueries produce the same set of columns, so `UNION ALL`
+        # All the subqueries produce the same set of columns, so UNION ALL
         # them together into a single query, aggregating results into
         # trial-level JSON dictionaries with the shape described in the docstring.
+        # NOTE: we use UNION ALL instead of just UNION to prevent unwanted
+        # de-duplication within subquery results.
         combined_query = f"""
             select
                 jsonb_object_agg(key, value) || jsonb_object_agg('trial_id', trial_id)

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -428,6 +428,11 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
         "assays": {
             "wes": [{"records": records * 3}],
             "rna": [{"records": records * 2}],
+            "mif": [
+                {"records": records * 3},
+                {"records": records},
+                {"records": records},
+            ],
             "elisa": [{"assay_xlsx": {"number_of_samples": 7}}],
             "nanostring": [
                 {"runs": [{"samples": records * 2}]},
@@ -449,14 +454,29 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
         "protocol_identifier": "tm1",
         "participants": [{"samples": []}],
         "assays": {
-            "cytof_10021": [{"records": records * 2}],
+            "cytof_10021": [
+                {"records": records * 2},
+                {"records": records * 2},
+                {"records": records},
+            ],
             "cytof_e4412": [
-                {"participants": [{"samples": records * 2}, {"samples": records}]}
+                {
+                    "participants": [
+                        {"samples": records},
+                        {"samples": records},
+                        {"samples": records * 2},
+                    ]
+                }
             ],
             "olink": {
                 "batches": [
-                    {"records": [{"number_of_samples": 2}, {"number_of_samples": 3}]},
-                    {"records": [{"number_of_samples": 5}]},
+                    {
+                        "records": [
+                            {"files": {"assay_npx": {"number_of_samples": 2}}},
+                            {"files": {"assay_npx": {"number_of_samples": 3}}},
+                        ]
+                    },
+                    {"records": [{"files": {"assay_npx": {"number_of_samples": 3}}}]},
                 ]
             },
         },
@@ -480,18 +500,19 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
     expected = sorted(
         [
             {
-                "cytof": 5.0,
-                "olink": 0.0,
+                "cytof": 9.0,
+                "olink": 8.0,
                 "trial_id": "tm2",
                 "file_size_bytes": 10,
                 "total_participants": 1,
                 "total_samples": 0,
-                "clinical_participants": 0,
+                "clinical_participants": 0.0,
                 "rna": 0.0,
                 "wes": 0.0,
                 "nanostring": 0.0,
                 "elisa": 0.0,
                 "h&e": 0.0,
+                "mif": 0.0,
             },
             {
                 "elisa": 7.0,
@@ -499,13 +520,14 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
                 "olink": 0.0,
                 "trial_id": "tm1",
                 "file_size_bytes": 5,
-                "total_participants": 2.0,
-                "total_samples": 3.0,
+                "total_participants": 2,
+                "total_samples": 3,
                 "clinical_participants": 7.0,
                 "rna": 2.0,
                 "wes": 3.0,
                 "nanostring": 3.0,
                 "h&e": 5.0,
+                "mif": 5.0,
             },
         ],
         key=sorter,


### PR DESCRIPTION
`union` de-duplicates in ways we don't want in this case, so use `union all` to join together all `TrialMetadata.get_summaries` subqueries.