### PR TITLE
Add support for trial- and assay-level permissions

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -169,7 +169,6 @@ class CommonColumns(BaseModel):  # type: ignore
         """List records in this table, with pagination support."""
         query = session.query(cls)
         query = cls._add_pagination_filters(query, **pagination_args)
-        print(query)
         return query.all()
 
     @classmethod

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -551,7 +551,7 @@ class Permissions(CommonColumns):
         # If a delete operation fails, all other deletes and the insertion will
         # be rolled back.
         for perm in perms_to_delete:
-            perm.delete(deleted_by=self.granted_by_user, commit=False)
+            session.delete(perm)
 
         # Always commit, because we don't want to grant IAM download unless this insert succeeds.
         super().insert(session=session, commit=True, compute_etag=compute_etag)

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -33,6 +33,8 @@ from sqlalchemy import (
     literal_column,
     not_,
     literal,
+    and_,
+    or_,
 )
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -407,6 +409,17 @@ class IAMException(Exception):
     pass
 
 
+EXTRA_DATA_TYPES = ["participants info", "samples info"]
+ALL_UPLOAD_TYPES = set(
+    [
+        *prism.SUPPORTED_MANIFESTS,
+        *prism.SUPPORTED_ASSAYS,
+        *prism.SUPPORTED_ANALYSES,
+        *EXTRA_DATA_TYPES,
+    ]
+)
+
+
 class Permissions(CommonColumns):
     __tablename__ = "permissions"
     __table_args__ = (
@@ -431,14 +444,19 @@ class Permissions(CommonColumns):
         UniqueConstraint(
             "granted_to_user", "trial_id", "upload_type", name="unique_perms"
         ),
+        CheckConstraint("trial_id is not null or upload_type is not null"),
     )
 
     # If user who granted this permission is deleted, this permission will be deleted.
     # TODO: is this what we want?
     granted_by_user = Column(Integer)
     granted_to_user = Column(Integer, nullable=False, index=True)
-    trial_id = Column(String, nullable=False, index=True)
-    upload_type = Column(String, nullable=False)
+    trial_id = Column(String, index=True)
+    upload_type = Column(String)
+
+    # Shorthand to make code related to trial- and upload-type-level permissions
+    # easier to interpret.
+    EVERY = None
 
     @with_default_session
     def insert(self, session: Session, commit: bool = True, compute_etag: bool = True):
@@ -446,8 +464,22 @@ class Permissions(CommonColumns):
         Insert this permission record into the database and add a corresponding IAM policy binding
         on the GCS data bucket.
 
+        If only a trial_id value is provided, then the permission denotes access to all upload_types
+        for the given trial.
+
+        If only an upload_type value is provided, then the permission denotes access to data of that
+        upload_type for all trials.
+
         NOTE: values provided to the `commit` argument will be ignored. This method always commits.
         """
+        if self.upload_type == self.EVERY and self.trial_id == self.EVERY:
+            raise ValueError("A permission must have a trial id or upload type.")
+
+        if self.upload_type not in ALL_UPLOAD_TYPES and self.upload_type != self.EVERY:
+            raise ValueError(
+                "cannot grant permission on invalid upload type:", self.upload_type
+            )
+
         grantee = Users.find_by_id(self.granted_to_user)
         if grantee is None:
             raise IntegrityError(
@@ -488,10 +520,39 @@ class Permissions(CommonColumns):
             )
 
         logger.info(
-            f"admin-action: {grantor.email} gave {grantee.email} the permission {self.upload_type} on {self.trial_id}"
+            f"admin-action: {grantor.email} gave {grantee.email} the permission {self.upload_type or 'all assays'} on {self.trial_id or 'all trials'}"
         )
 
+        # If this is a permission granting the user access to all trials for
+        # a given upload type or all upload types for a given trial, delete
+        # any related trial-upload type specific permissions to avoid
+        # redundancy in the database and in conditional IAM bindings.
+        perms_to_delete = (
+            session.query(Permissions)
+            .filter(
+                Permissions.granted_to_user == self.granted_to_user,
+                # If inserting a cross-trial perm, then select relevant
+                # trial-specific perms for deletion.
+                Permissions.trial_id != self.EVERY
+                if self.trial_id == self.EVERY
+                else Permissions.trial_id == self.trial_id,
+                # If inserting a cross-upload type perm, then select relevant
+                # upload type-specific perms for deletion.
+                Permissions.upload_type != self.EVERY
+                if self.upload_type == self.EVERY
+                else Permissions.upload_type,
+            )
+            .all()
+        )
+
+        # Add any related permission deletions to the insertion transaction.
+        # If a delete operation fails, all other deletes and the insertion will
+        # be rolled back.
+        for perm in perms_to_delete:
+            perm.delete(deleted_by=self.granted_by_user, commit=False)
+
         # Always commit, because we don't want to grant IAM download unless this insert succeeds.
+        print(self.__dict__)
         super().insert(session=session, commit=True, compute_etag=compute_etag)
 
         # Don't make any GCS changes if this user doesn't have download access
@@ -501,7 +562,13 @@ class Permissions(CommonColumns):
         try:
             # Grant IAM permission in GCS only if db insert worked
             grant_download_access(grantee.email, self.trial_id, self.upload_type)
+            # Remove permissions staged for deletion, if any
+            for perm in perms_to_delete:
+                revoke_download_access(grantee.email, perm.trial_id, perm.upload_type)
         except Exception as e:
+            # Add back deleted permissions, if any
+            for perm in perms_to_delete:
+                perm.insert()
             # Delete the just-created permissions record
             super().delete()
             raise IAMException("IAM grant failed.") from e
@@ -538,7 +605,7 @@ class Permissions(CommonColumns):
                 ) from e
 
         logger.info(
-            f"admin-action: {deleted_by_user.email} removed from {grantee.email} the permission {self.upload_type} on {self.trial_id}"
+            f"admin-action: {deleted_by_user.email} removed from {grantee.email} the permission {self.upload_type or 'all assays'} on {self.trial_id or 'all trials'}"
         )
         super().delete(session=session, commit=True)
 
@@ -551,12 +618,25 @@ class Permissions(CommonColumns):
     @staticmethod
     @with_default_session
     def find_for_user_trial_type(
-        user_id: int, trial_id: str, type_: str, session: Session
+        user_id: int, trial_id: str, upload_type: str, session: Session
     ):
-        """Check if a Permissions record exists for the given user, trial, and type."""
+        """
+        Check if a Permissions record exists for the given user, trial, and type.
+        The result may be a trial- or assay-level permission that encompasses the 
+        given trial id or upload type.
+        """
         return (
             session.query(Permissions)
-            .filter_by(granted_to_user=user_id, trial_id=trial_id, upload_type=type_)
+            .filter(
+                Permissions.granted_to_user == user_id,
+                tuple_(Permissions.trial_id, Permissions.upload_type).in_(
+                    [
+                        (trial_id, upload_type),
+                        (trial_id, Permissions.EVERY),
+                        (Permissions.EVERY, upload_type),
+                    ]
+                ),
+            )
             .first()
         )
 
@@ -1628,11 +1708,24 @@ class DownloadableFiles(CommonColumns):
         # Admins and NCI biobank users can view all files
         if user and not user.is_admin() and not user.is_nci_user():
             permissions = Permissions.find_for_user(user.id)
-            perm_set = [(p.trial_id, p.upload_type) for p in permissions]
-            file_tuples = tuple_(
+            full_trial_perms, full_type_perms, trial_type_perms = [], [], []
+            for perm in permissions:
+                if perm.upload_type is None:
+                    full_trial_perms.append(perm.trial)
+                elif perm.trial_id is None:
+                    full_type_perms.append(perm.upload_type)
+                else:
+                    trial_type_perms.append((perm.trial_id, perm.upoad_type))
+            df_tuples = tuple_(
                 DownloadableFiles.trial_id, DownloadableFiles.upload_type
             )
-            file_filters.append(file_tuples.in_(perm_set))
+            file_filters.append(
+                or_(
+                    DownloadableFiles.trial_id.in_(full_trial_perms),
+                    DownloadableFiles.upload_type.in_(full_type_perms),
+                    df_tuples.in_(trial_type_perms),
+                )
+            )
 
         def filter_files(query: Query) -> Query:
             return query.filter(*file_filters)

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -569,9 +569,9 @@ class Permissions(CommonColumns):
         except Exception as e:
             # Add back deleted permissions, if any
             for perm in perms_to_delete:
-                perm.insert()
+                perm.insert(session=session)
             # Delete the just-created permissions record
-            super().delete()
+            super().delete(session=session)
             raise IAMException("IAM grant failed.") from e
 
     @with_default_session

--- a/cidc_api/resources/info.py
+++ b/cidc_api/resources/info.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import NotFound, BadRequest
 from cidc_schemas import prism
 
 from ..shared.auth import public
-from ..models import TrialMetadata, DownloadableFiles
+from ..models import TrialMetadata, DownloadableFiles, EXTRA_DATA_TYPES
 
 info_bp = Blueprint("info", __name__)
 
@@ -32,9 +32,6 @@ def analyses():
 def manifests():
     """List all supported manifests"""
     return jsonify(prism.SUPPORTED_MANIFESTS)
-
-
-EXTRA_DATA_TYPES = ["participants info", "samples info"]
 
 
 @info_bp.route("extra_data_types", methods=["GET"])

--- a/cidc_api/shared/gcloud_client.py
+++ b/cidc_api/shared/gcloud_client.py
@@ -198,23 +198,32 @@ def upload_xlsx_to_intake_bucket(
     return f"https://console.cloud.google.com/storage/browser/_details/{bucket_name}/{blob_name}"
 
 
-def grant_download_access(user_email: str, trial_id: str, upload_type: str):
+def grant_download_access(
+    user_email: str, trial_id: Optional[str], upload_type: Optional[str]
+):
     """
     Give a user download access to all objects in a trial of a particular upload type.
+
+    If trial_id is None, then grant access to all trials.
+
+    If upload_type is None, then grant access to all upload_types.
+
     If the user already has download access for this trial and upload type, regrant the
-    permission with a new, extended TTL. 
-    
+    permission with a new, extended TTL.
+
     Return the GCS URI to which access has been granted.
     """
     prefix = _build_trial_upload_prefix(trial_id, upload_type)
 
-    logger.info(f"Granting download access on {prefix}* to {user_email}")
+    logger.info(f"Granting download access on prefix {prefix} to {user_email}")
 
     bucket = _get_bucket(GOOGLE_DATA_BUCKET)
     grant_expiring_gcs_access(bucket, GOOGLE_DOWNLOAD_ROLE, user_email, prefix)
 
 
-def revoke_download_access(user_email: str, trial_id: str, upload_type: str):
+def revoke_download_access(
+    user_email: str, trial_id: Optional[str], upload_type: Optional[str]
+):
     """
     Revoke a user's download access to all objects in a trial of a particular upload type.
 
@@ -228,7 +237,11 @@ def revoke_download_access(user_email: str, trial_id: str, upload_type: str):
     return revoke_expiring_gcs_access(bucket, GOOGLE_DOWNLOAD_ROLE, user_email, prefix)
 
 
-def _build_trial_upload_prefix(trial_id: str, upload_type: str) -> str:
+def _build_trial_upload_prefix(
+    trial_id: Optional[str], upload_type: Optional[str]
+) -> str:
+    trial_id = trial_id or "*"
+    upload_type = upload_type or "*"
     broad_upload_type = upload_type.lower().replace(" ", "_").split("_", 1)[0]
     return f"{trial_id}/{broad_upload_type}"
 

--- a/cidc_api/shared/gcloud_client.py
+++ b/cidc_api/shared/gcloud_client.py
@@ -231,7 +231,7 @@ def revoke_download_access(
     """
     prefix = _build_trial_upload_prefix(trial_id, upload_type)
 
-    logger.info(f"Revoking download access on {prefix}* to {user_email}")
+    logger.info(f"Revoking download access on {prefix} from {user_email}")
 
     bucket = _get_bucket(GOOGLE_DATA_BUCKET)
     return revoke_expiring_gcs_access(bucket, GOOGLE_DOWNLOAD_ROLE, user_email, prefix)

--- a/cidc_api/shared/rest_utils.py
+++ b/cidc_api/shared/rest_utils.py
@@ -48,6 +48,9 @@ def unmarshal_request(schema: BaseSchema, kwarg_name: str, load_sqla: bool = Tru
                     body = loaded_instance
                 # Run any model-defined field validations
                 loaded_instance.validate()
+            # The many ways that validation errors might get raised...
+            except ValueError as e:
+                raise UnprocessableEntity(str(e))
             except ValidationError as e:
                 raise UnprocessableEntity(e.messages)
             except ValidationMultiError as e:

--- a/migrations/versions/40d16813c5dd_permissions_nullable_trial_and_upload_.py
+++ b/migrations/versions/40d16813c5dd_permissions_nullable_trial_and_upload_.py
@@ -1,0 +1,40 @@
+"""permissions nullable trial and upload type
+
+Revision ID: 40d16813c5dd
+Revises: 509970372467
+Create Date: 2021-03-29 12:08:35.146241
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "40d16813c5dd"
+down_revision = "509970372467"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "permissions", "trial_id", existing_type=sa.VARCHAR(), nullable=True
+    )
+    op.alter_column(
+        "permissions", "upload_type", existing_type=sa.VARCHAR(), nullable=True
+    )
+    op.create_check_constraint(
+        "ck_nonnull_trial_id_or_upload_type",
+        "permissions",
+        "trial_id is not null or upload_type is not null",
+    )
+
+
+def downgrade():
+    op.drop_constraint("ck_nonnull_trial_id_or_upload_type", "permissions")
+    op.alter_column(
+        "permissions", "upload_type", existing_type=sa.VARCHAR(), nullable=False
+    )
+    op.alter_column(
+        "permissions", "trial_id", existing_type=sa.VARCHAR(), nullable=False
+    )

--- a/migrations/versions/a0f25824b2ae_permissions_nullable_trial_and_upload_.py
+++ b/migrations/versions/a0f25824b2ae_permissions_nullable_trial_and_upload_.py
@@ -8,7 +8,6 @@ Create Date: 2021-04-20 14:57:14.708607
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "a0f25824b2ae"
 down_revision = "7d3ad965db30"
@@ -23,6 +22,31 @@ def upgrade():
     op.alter_column(
         "permissions", "upload_type", existing_type=sa.VARCHAR(), nullable=True
     )
+
+    # By default, Postgres allows multiple NULL values in its unique indexes,
+    # so we need to introduce additional uniqueness constraints that disallow
+    # multiple permissions with NULL trial_id's or upload_type's.
+    op.execute(
+        """
+            CREATE UNIQUE INDEX 
+                unique_trial_id_upload_type_is_null_perms
+            ON 
+                permissions (granted_to_user, trial_id, (upload_type IS NULL)) 
+            WHERE 
+                upload_type IS NULL
+        """
+    )
+    op.execute(
+        """
+            CREATE UNIQUE INDEX 
+                unique_upload_type_trial_id_is_null_perms
+            ON 
+                permissions (granted_to_user, (trial_id IS NULL), upload_type) 
+            WHERE 
+                trial_id IS NULL
+        """
+    )
+
     op.create_check_constraint(
         "ck_nonnull_trial_id_or_upload_type",
         "permissions",
@@ -31,6 +55,14 @@ def upgrade():
 
 
 def downgrade():
+    op.execute("DROP INDEX unique_trial_id_upload_type_is_null_perms")
+    op.execute("DROP INDEX unique_upload_type_trial_id_is_null_perms")
+
+    # NOTE: it is up to the developer making the decision to downgrade
+    # to delete the corresponding GCS IAM permissions via some other route.
+    # I don't think we want database migrations performing IAM actions.
+    op.execute("DELETE FROM permissions WHERE upload_type IS NULL OR trial_id IS NULL")
+
     op.drop_constraint("ck_nonnull_trial_id_or_upload_type", "permissions")
     op.alter_column(
         "permissions", "upload_type", existing_type=sa.VARCHAR(), nullable=False

--- a/migrations/versions/a0f25824b2ae_permissions_nullable_trial_and_upload_.py
+++ b/migrations/versions/a0f25824b2ae_permissions_nullable_trial_and_upload_.py
@@ -1,8 +1,8 @@
 """permissions nullable trial and upload type
 
-Revision ID: 40d16813c5dd
-Revises: 509970372467
-Create Date: 2021-03-29 12:08:35.146241
+Revision ID: a0f25824b2ae
+Revises: 7d3ad965db30
+Create Date: 2021-04-20 14:57:14.708607
 
 """
 from alembic import op
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = "40d16813c5dd"
-down_revision = "509970372467"
+revision = "a0f25824b2ae"
+down_revision = "7d3ad965db30"
 branch_labels = None
 depends_on = None
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,6 +2,7 @@ pytest~=6.0.1
 black==19.3b0
 pre-commit==1.17.0
 ipython
+flask-shell-ipython
 ## plotly dash testing dependencies ##
 webdriver_manager
 percy

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         "cidc_api.models.files",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.24.19",
+    version="0.24.20",
     zip_safe=False,
 )

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -549,13 +549,13 @@ def test_create_assay_upload(clean_db):
 
     # Should fail, since trial doesn't exist yet
     with pytest.raises(IntegrityError):
-        UploadJobs.create("wes", EMAIL, gcs_file_map, metadata_patch, gcs_xlsx_uri)
+        UploadJobs.create("wes_bam", EMAIL, gcs_file_map, metadata_patch, gcs_xlsx_uri)
     clean_db.rollback()
 
     TrialMetadata.create(TRIAL_ID, METADATA)
 
     new_job = UploadJobs.create(
-        "wes", EMAIL, gcs_file_map, metadata_patch, gcs_xlsx_uri
+        "wes_bam", EMAIL, gcs_file_map, metadata_patch, gcs_xlsx_uri
     )
     job = UploadJobs.find_by_id_and_email(new_job.id, PROFILE["email"])
     assert len(new_job.gcs_file_map) == len(job.gcs_file_map)
@@ -651,7 +651,7 @@ def test_assay_upload_ingestion_success(clean_db, monkeypatch, caplog):
     new_user = Users.create(PROFILE)
     trial = TrialMetadata.create(TRIAL_ID, METADATA)
     assay_upload = UploadJobs.create(
-        upload_type="cytof",
+        upload_type="ihc",
         uploader_email=EMAIL,
         gcs_file_map={},
         metadata={PROTOCOL_ID_FIELD_NAME: TRIAL_ID},
@@ -702,14 +702,14 @@ def test_create_downloadable_file_from_metadata(clean_db, monkeypatch):
     # Create files with empty or "null" additional metadata
     for nullish_value in ["null", None, {}]:
         df = DownloadableFiles.create_from_metadata(
-            TRIAL_ID, "wes", file_metadata, additional_metadata=nullish_value
+            TRIAL_ID, "wes_bam", file_metadata, additional_metadata=nullish_value
         )
         clean_db.refresh(df)
         assert df.additional_metadata == {}
 
     # Create the file
     DownloadableFiles.create_from_metadata(
-        TRIAL_ID, "wes", file_metadata, additional_metadata=additional_metadata
+        TRIAL_ID, "wes_bam", file_metadata, additional_metadata=additional_metadata
     )
 
     # Check that we created the file
@@ -730,7 +730,7 @@ def test_create_downloadable_file_from_metadata(clean_db, monkeypatch):
     # Check that artifact upload publishes
     DownloadableFiles.create_from_metadata(
         TRIAL_ID,
-        "wes",
+        "wes_bam",
         file_metadata,
         additional_metadata=additional_metadata,
         alert_artifact_upload=True,
@@ -743,7 +743,7 @@ def test_downloadable_files_additional_metadata_default(clean_db):
     TrialMetadata.create(TRIAL_ID, METADATA)
     df = DownloadableFiles(
         trial_id=TRIAL_ID,
-        upload_type="wes",
+        upload_type="wes_bam",
         object_url="10021/Patient 1/sample 1/aliquot 1/wes_forward.fastq",
         file_size_bytes=1,
         md5_hash="hash1234",
@@ -951,7 +951,7 @@ def test_permissions_insert(clean_db, monkeypatch, caplog):
 
     # if don't give granted_by_user
     perm = Permissions(
-        granted_to_user=user.id, trial_id=trial.trial_id, upload_type="wes"
+        granted_to_user=user.id, trial_id=trial.trial_id, upload_type="wes_bam"
     )
     with pytest.raises(IntegrityError, match="`granted_by_user` user must be given"):
         perm.insert()
@@ -962,7 +962,7 @@ def test_permissions_insert(clean_db, monkeypatch, caplog):
     perm = Permissions(
         granted_to_user=user.id,
         trial_id=trial.trial_id,
-        upload_type="wes",
+        upload_type="wes_bam",
         granted_by_user=999999,
     )
     with pytest.raises(IntegrityError, match="`granted_by_user` user must exist"):
@@ -974,7 +974,7 @@ def test_permissions_insert(clean_db, monkeypatch, caplog):
     perm = Permissions(
         granted_to_user=999999,
         trial_id=trial.trial_id,
-        upload_type="wes",
+        upload_type="wes_bam",
         granted_by_user=user.id,
     )
     with pytest.raises(IntegrityError, match="`granted_to_user` user must exist"):
@@ -986,7 +986,7 @@ def test_permissions_insert(clean_db, monkeypatch, caplog):
     perm = Permissions(
         granted_to_user=user.id,
         trial_id=trial.trial_id,
-        upload_type="wes",
+        upload_type="wes_bam",
         granted_by_user=user.id,
     )
     with caplog.at_level(logging.DEBUG):
@@ -994,7 +994,7 @@ def test_permissions_insert(clean_db, monkeypatch, caplog):
     _insert.assert_called_once()
     assert any(
         log_record.message.strip()
-        == f"admin-action: {user.email} gave {user.email} the permission wes on {trial.trial_id}"
+        == f"admin-action: {user.email} gave {user.email} the permission wes_bam on {trial.trial_id}"
         for log_record in caplog.records
     )
     gcloud_client.grant_download_access.assert_called_once()
@@ -1007,7 +1007,7 @@ def test_permissions_insert(clean_db, monkeypatch, caplog):
     perm = Permissions(
         granted_to_user=user.id,
         trial_id=trial.trial_id,
-        upload_type="cytof",
+        upload_type="ihc",
         granted_by_user=user.id,
     )
     perm.insert()
@@ -1066,7 +1066,7 @@ def test_permissions_broad_perms(clean_db, monkeypatch):
     assert perm.upload_type == "olink"
 
     # Getting perms for a particular user-trial-type returns broader perms
-    perm = Permissions.find_for_user_trial_type(user.id, trial.trial_id, "cytof")
+    perm = Permissions.find_for_user_trial_type(user.id, trial.trial_id, "ihc")
     assert perm is not None and perm.upload_type is None
     perm = Permissions.find_for_user_trial_type(user.id, "some random trial", "olink")
     assert perm is not None and perm.trial_id is None
@@ -1082,7 +1082,7 @@ def test_permissions_delete(clean_db, monkeypatch, caplog):
     perm = Permissions(
         granted_to_user=user.id,
         trial_id=trial.trial_id,
-        upload_type="wes",
+        upload_type="wes_bam",
         granted_by_user=user.id,
     )
     perm.insert()
@@ -1100,7 +1100,7 @@ def test_permissions_delete(clean_db, monkeypatch, caplog):
     gcloud_client.grant_download_access.assert_not_called()
     assert any(
         log_record.message.strip()
-        == f"admin-action: {user.email} removed from {user.email} the permission wes on {trial.trial_id}"
+        == f"admin-action: {user.email} removed from {user.email} the permission wes_bam on {trial.trial_id}"
         for log_record in caplog.records
     )
 
@@ -1125,7 +1125,7 @@ def test_permissions_delete(clean_db, monkeypatch, caplog):
     perm = Permissions(
         granted_to_user=user.id,
         trial_id=trial.trial_id,
-        upload_type="cytof",
+        upload_type="ihc",
         granted_by_user=user.id,
     )
     perm.insert()
@@ -1149,7 +1149,7 @@ def test_permissions_grant_iam_permissions(clean_db, monkeypatch):
     trial = TrialMetadata(trial_id=TRIAL_ID, metadata_json=METADATA)
     trial.insert()
 
-    upload_types = ["wes", "cytof", "rna", "plasma"]
+    upload_types = ["wes_bam", "ihc", "rna_fastq", "plasma"]
     for upload_type in upload_types:
         Permissions(
             granted_to_user=user.id,
@@ -1185,7 +1185,7 @@ def test_permissions_grant_all_iam_permissions(clean_db, monkeypatch):
     trial = TrialMetadata(trial_id=TRIAL_ID, metadata_json=METADATA)
     trial.insert()
 
-    upload_types = ["wes", "cytof", "rna", "plasma"]
+    upload_types = ["wes_bam", "ihc", "rna_fastq", "plasma"]
     for upload_type in upload_types:
         Permissions(
             granted_to_user=user.id,
@@ -1219,7 +1219,7 @@ def test_permissions_revoke_all_iam_permissions(clean_db, monkeypatch):
     trial = TrialMetadata(trial_id=TRIAL_ID, metadata_json=METADATA)
     trial.insert()
 
-    upload_types = ["wes", "cytof", "rna", "plasma"]
+    upload_types = ["wes_bam", "ihc", "rna_fastq", "plasma"]
     for upload_type in upload_types:
         Permissions(
             granted_to_user=user.id,
@@ -1286,7 +1286,7 @@ def test_user_get_data_access_report(clean_db, monkeypatch):
     trial = TrialMetadata(trial_id=TRIAL_ID, metadata_json=METADATA)
     trial.insert()
 
-    upload_types = ["wes", "cytof"]
+    upload_types = ["wes_bam", "ihc"]
 
     # Note that admins don't need permissions to view data,
     # so we're deliberately issuing unnecessary permissions here.
@@ -1317,4 +1317,4 @@ def test_user_get_data_access_report(clean_db, monkeypatch):
         if user == admin_user:
             assert set(["*"]) == set(user_df.permissions)
         else:
-            assert set(user_df.permissions).issubset(["wes,cytof", "cytof,wes"])
+            assert set(user_df.permissions).issubset(["wes_bam,ihc", "ihc,wes_bam"])

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -33,7 +33,7 @@ def setup_user(cidc_api, monkeypatch) -> int:
 
 
 trial_id = "test-trial"
-upload_types = ["wes", "cytof"]
+upload_types = ["wes_bam", "cytof_10021"]
 
 
 def setup_downloadable_files(cidc_api) -> Tuple[int, int]:
@@ -57,11 +57,11 @@ def setup_downloadable_files(cidc_api) -> Tuple[int, int]:
         )
 
     wes_file = make_file(
-        f"{trial_id}/wes/.../reads_123.bam", "wes", "/wes/r1_.fastq.gz"
+        f"{trial_id}/wes/.../reads_123.bam", "wes_bam", "/wes/r1_.fastq.gz"
     )
     cytof_file = make_file(
         f"{trial_id}/cytof/.../analysis.zip",
-        "cytof",
+        "cytof_10021",
         "/cytof_10021_analysis/analysis.zip",
     )
 

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -32,41 +32,45 @@ def setup_user(cidc_api, monkeypatch) -> int:
         return current_user.id
 
 
-trial_id = "test-trial"
+trial_id_1 = "test-trial-1"
+trial_id_2 = "test-trial-2"
 upload_types = ["wes_bam", "cytof_10021"]
 
 
 def setup_downloadable_files(cidc_api) -> Tuple[int, int]:
     """Insert two downloadable files into the database."""
     metadata_json = {
-        "protocol_identifier": trial_id,
+        "protocol_identifier": trial_id_1,
         "allowed_collection_event_names": [],
         "allowed_cohort_names": [],
         "participants": [],
     }
-    trial = TrialMetadata(trial_id=trial_id, metadata_json=metadata_json)
+    trial_1 = TrialMetadata(trial_id=trial_id_1, metadata_json=metadata_json)
+    trial_2 = TrialMetadata(trial_id=trial_id_2, metadata_json=metadata_json)
 
-    def make_file(object_url, upload_type, facet_group) -> DownloadableFiles:
+    def make_file(trial_id, object_url, upload_type, facet_group) -> DownloadableFiles:
         return DownloadableFiles(
             trial_id=trial_id,
             upload_type=upload_type,
-            object_url=object_url,
+            object_url=f"{trial_id}/{object_url}",
             facet_group=facet_group,
             uploaded_timestamp=datetime.now(),
             file_size_bytes=0,
         )
 
     wes_file = make_file(
-        f"{trial_id}/wes/.../reads_123.bam", "wes_bam", "/wes/r1_.fastq.gz"
+        trial_id_1, "wes/.../reads_123.bam", "wes_bam", "/wes/r1_.fastq.gz"
     )
     cytof_file = make_file(
-        f"{trial_id}/cytof/.../analysis.zip",
+        trial_id_2,
+        "cytof/.../analysis.zip",
         "cytof_10021",
         "/cytof_10021_analysis/analysis.zip",
     )
 
     with cidc_api.app_context():
-        trial.insert()
+        trial_1.insert()
+        trial_2.insert()
         wes_file.insert()
         cytof_file.insert()
 
@@ -86,22 +90,26 @@ def test_list_downloadable_files(cidc_api, clean_db, monkeypatch):
     assert len(res.json["_items"]) == 0
     assert res.json["_meta"]["total"] == 0
 
-    # Give the user one permission
-    with cidc_api.app_context():
-        perm = Permissions(
-            granted_to_user=user_id,
-            trial_id=trial_id,
-            upload_type=upload_types[0],
-            granted_by_user=user_id,
-        )
-        perm.insert()
+    # Test a couple different permission configurations that should
+    # produce the same result in this case.
+    for kwargs in [
+        {"trial_id": trial_id_1, "upload_type": upload_types[0]},
+        {"upload_type": upload_types[0]},
+        {"trial_id": trial_id_1},
+    ]:
+        # Give the user one permission
+        with cidc_api.app_context():
+            perm = Permissions(
+                granted_to_user=user_id, granted_by_user=user_id, **kwargs
+            )
+            perm.insert()
 
-    # Non-admins can view files for which they have permission
-    res = client.get("/downloadable_files")
-    assert res.status_code == 200
-    assert len(res.json["_items"]) == 1
-    assert res.json["_meta"]["total"] == 1
-    assert res.json["_items"][0]["id"] == file_id_1
+        # Non-admins can view files for which they have permission
+        res = client.get("/downloadable_files")
+        assert res.status_code == 200
+        assert len(res.json["_items"]) == 1
+        assert res.json["_meta"]["total"] == 1
+        assert res.json["_items"][0]["id"] == file_id_1
 
     # Non-admin filter queries exclude files they aren't allowed to view
     res = client.get(f"/downloadable_files?facets=Assay Type|CyTOF|Analysis Results")
@@ -156,7 +164,7 @@ def test_get_downloadable_file(cidc_api, clean_db, monkeypatch):
     with cidc_api.app_context():
         perm = Permissions(
             granted_to_user=user_id,
-            trial_id=trial_id,
+            trial_id=trial_id_1,
             upload_type=upload_types[0],
             granted_by_user=user_id,
         )
@@ -189,7 +197,7 @@ def test_get_related_files(cidc_api, clean_db, monkeypatch):
     object_url = "/foo/bar"
     with cidc_api.app_context():
         DownloadableFiles(
-            trial_id=trial_id,
+            trial_id=trial_id_1,
             upload_type="wes",
             object_url=object_url,
             facet_group="/wes/r2_.fastq.gz",  # this is what makes this file "related"
@@ -205,7 +213,7 @@ def test_get_related_files(cidc_api, clean_db, monkeypatch):
     with cidc_api.app_context():
         perm = Permissions(
             granted_to_user=user_id,
-            trial_id=trial_id,
+            trial_id=trial_id_1,
             upload_type=upload_types[0],
             granted_by_user=user_id,
         )
@@ -246,7 +254,7 @@ def test_get_filelist(cidc_api, clean_db, monkeypatch):
     with cidc_api.app_context():
         perm = Permissions(
             granted_to_user=user_id,
-            trial_id=trial_id,
+            trial_id=trial_id_1,
             upload_type=upload_types[0],
             granted_by_user=user_id,
         )
@@ -258,7 +266,7 @@ def test_get_filelist(cidc_api, clean_db, monkeypatch):
     assert "text/tsv" in res.headers["Content-Type"]
     assert "filename=filelist.tsv" in res.headers["Content-Disposition"]
     assert res.data.decode("utf-8") == (
-        f"gs://{GOOGLE_DATA_BUCKET}/{trial_id}/wes/.../reads_123.bam\t{trial_id}_wes_..._reads_123.bam\n"
+        f"gs://{GOOGLE_DATA_BUCKET}/{trial_id_1}/wes/.../reads_123.bam\t{trial_id_1}_wes_..._reads_123.bam\n"
     )
 
     # Admins don't need permissions to get files
@@ -266,8 +274,8 @@ def test_get_filelist(cidc_api, clean_db, monkeypatch):
     res = client.post(url, json=short_file_list)
     assert res.status_code == 200
     assert res.data.decode("utf-8") == (
-        f"gs://{GOOGLE_DATA_BUCKET}/{trial_id}/wes/.../reads_123.bam\t{trial_id}_wes_..._reads_123.bam\n"
-        f"gs://{GOOGLE_DATA_BUCKET}/{trial_id}/cytof/.../analysis.zip\t{trial_id}_cytof_..._analysis.zip\n"
+        f"gs://{GOOGLE_DATA_BUCKET}/{trial_id_1}/wes/.../reads_123.bam\t{trial_id_1}_wes_..._reads_123.bam\n"
+        f"gs://{GOOGLE_DATA_BUCKET}/{trial_id_2}/cytof/.../analysis.zip\t{trial_id_2}_cytof_..._analysis.zip\n"
     )
 
     # Clear inserted file records
@@ -280,7 +288,7 @@ def test_get_filelist(cidc_api, clean_db, monkeypatch):
         for id in long_file_list:
             DownloadableFiles(
                 id=id,
-                trial_id=trial_id,
+                trial_id=trial_id_1,
                 object_url=str(id),
                 upload_type="",
                 file_size_bytes=0,
@@ -316,7 +324,7 @@ def test_get_filter_facets(cidc_api, clean_db, monkeypatch):
     with cidc_api.app_context():
         perm = Permissions(
             granted_to_user=user_id,
-            trial_id=trial_id,
+            trial_id=trial_id_1,
             upload_type=upload_types[0],
             granted_by_user=user_id,
         )
@@ -329,7 +337,10 @@ def test_get_filter_facets(cidc_api, clean_db, monkeypatch):
     make_admin(user_id, cidc_api)
     res = client.get("/downloadable_files/filter_facets")
     assert res.status_code == 200
-    assert res.json["trial_ids"] == [{"label": trial_id, "count": 2}]
+    assert res.json["trial_ids"] == [
+        {"label": trial_id_1, "count": 1},
+        {"label": trial_id_2, "count": 1},
+    ]
     check_facet_counts(res.json["facets"], wes_count=1, cytof_count=1)
 
     # Trial facets are governed by data category facets
@@ -370,7 +381,7 @@ def test_get_download_url(cidc_api, clean_db, monkeypatch):
     with cidc_api.app_context():
         perm = Permissions(
             granted_to_user=user_id,
-            trial_id=trial_id,
+            trial_id=trial_id_1,
             upload_type=upload_types[0],
             granted_by_user=user_id,
         )

--- a/tests/resources/test_permissions.py
+++ b/tests/resources/test_permissions.py
@@ -191,11 +191,15 @@ def test_create_permission(cidc_api, clean_db, monkeypatch):
     gcloud_client.grant_download_access.assert_not_called()
     gcloud_client.revoke_download_access.assert_not_called()
 
+    with cidc_api.app_context():
+        clean_db.query(Permissions).delete()
+        clean_db.commit()
+
     # The permission grantee must have <= GOOGLE_MAX_DOWNLOAD_PERMISSIONS
     perm["granted_to_user"] = current_user_id
     inserts_fail_eventually = False
     upload_types = list(ALL_UPLOAD_TYPES)
-    for i in range(GOOGLE_MAX_DOWNLOAD_PERMISSIONS):
+    for i in range(GOOGLE_MAX_DOWNLOAD_PERMISSIONS + 1):
         gcloud_client.reset_mocks()
         perm["upload_type"] = upload_types[i]
         res = client.post("permissions", json=perm)

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -66,13 +66,13 @@ def setup_trial_metadata(cidc_api, user_id=None) -> Tuple[int, int]:
             Permissions(
                 granted_to_user=user_id,
                 trial_id=trial.trial_id,
-                upload_type="wes",
+                upload_type="olink",
                 granted_by_user=user_id,
             ).insert()
             Permissions(
                 granted_to_user=user_id,
                 trial_id=trial.trial_id,
-                upload_type="cytof",
+                upload_type="ihc",
                 granted_by_user=user_id,
             ).insert()
         return trial.id

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -83,7 +83,7 @@ downloadable_files = {
     "json": {
         "id": TEST_RECORD_ID,
         "trial_id": trial_metadata["json"]["trial_id"],
-        "upload_type": "rna",
+        "upload_type": "rna_bam",
         "object_url": f'{trial_metadata["json"]["trial_id"]}/rna/.../r1_123.fastq.gz',
         "facet_group": "/rna/reads_.bam",
         "uploaded_timestamp": datetime.now(),


### PR DESCRIPTION
This PR makes it possible for admins to grant any user access to all data across assays for a trial or to all data across trials for an assay.