### PR TITLE
New facets and file details from RNAseq DM upgrade 

### DIFF
--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -279,6 +279,11 @@ details_dict = {
         "the log file produced by the Salmon analysis",
         "A plain-text file containing the time and output of all logging by Salmon during sample analysis.",
     ),
+    "/rna/analysis/microbiome/_addSample_report.txt": FileDetails(
+        "miscellaneous",
+        "centrifuge summary output file",
+        "Centrifuge output file contains name of a genome, taxonomic ID and rank, and also the proportion of this genome normalized by its genomic length",
+    ),
     # Nanostring
     "/nanostring/.rcc": FileDetails(
         "source",

--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -289,6 +289,16 @@ details_dict = {
         "TRUST4 final report file",
         "This report file focuses on CDR3 and is compatible with other repertoire analysis tools, such as VDJTools.",
     ),
+    "/rna/analysis/fusion/fusion_predictions.abridged_addSample.tsv": FileDetails(
+        "miscellaneous",
+        "fusion analysis report file",
+        "This report file contains valiated fusion gene pairs found in all samples including their gene expression.",
+    ),
+    "/rna/analysis/msisensor/single/run_/_msisensor.txt": FileDetails(
+        "miscellaneous",
+        "msisensor report file",
+        "This report file contains MSI score this report file contains MSI score.",
+    ),
     # Nanostring
     "/nanostring/.rcc": FileDetails(
         "source",

--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -209,25 +209,15 @@ details_dict = {
         "plain text statistics of sorted.bam file alignment",
         "A plain-text file of summary statistics of the alignment. Provides informaion useful for determining sample quality and discovering alignment errors.",
     ),
-    "/rna/analysis/star/downsampling.bam": FileDetails(
+    "/rna/analysis/star/.transcriptome.bam": FileDetails(
         "miscellaneous",
-        "bam file of downsampled aligned reads with index downsampling.bam.bai",
-        "A subset of the aligned reads in the standard BAM binary format, sorted by their coordinate in the genome (similar to `samtools sort`). Subsetting is done to speed the quality control done via RSeQC.",
+        "transcriptome bam file",
+        "A bam file containing the transcriptomefrom RNAseq expression analyses",
     ),
-    "/rna/analysis/star/downsampling.bam.bai": FileDetails(
+    "/rna/analysis/star/.Chimeric.out.junction": FileDetails(
         "miscellaneous",
-        "bam index file of downsampled aligned reads that accompanies downsampling.bam",
-        "The index for the subset of the aligned reads in the standard BAI binary format, sorted by their coordinate in the genome (similar to `samtools sort`). Subsetting is done to speed the quality control done via RSeQC.",
-    ),
-    "/rna/analysis/rseqc/downsampling_housekeeping.bam": FileDetails(
-        "miscellaneous",
-        "bam file of the downsampled aligned reads of housekeeping genes with index downsampling_housekeeping.bam.bai",
-        "A small subset of the reads aligned to housekeeping genes in the standard BAM binary format.",
-    ),
-    "/rna/analysis/rseqc/downsampling_housekeeping.bam.bai": FileDetails(
-        "miscellaneous",
-        "bam index file of the downsampled aligned reads of housekeeping genes that accompanies downsampling_housekeeping.bam",
-        "The index for the small subset of the reads aligned to housekeeping genes in the standard BAM binary format.",
+        "Chimeric junction output",
+        "Chimeric junction output for fusion calling",
     ),
     "/rna/analysis/rseqc/read_distrib.txt": FileDetails(
         "clinical",

--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -299,6 +299,11 @@ details_dict = {
         "msisensor report file",
         "This report file contains MSI score this report file contains MSI score.",
     ),
+    "/rna/analysis/neoantigen/.genotype.json": FileDetails(
+        "miscellaneous",
+        "arcasHLA report file",
+        "This report file contains MHC class I & II HLA alleles.",
+    ),
     # Nanostring
     "/nanostring/.rcc": FileDetails(
         "source",

--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -284,6 +284,11 @@ details_dict = {
         "centrifuge summary output file",
         "Centrifuge output file contains name of a genome, taxonomic ID and rank, and also the proportion of this genome normalized by its genomic length",
     ),
+    "/rna/analysis/trust4/_report.tsv": FileDetails(
+        "miscellaneous",
+        "TRUST4 final report file",
+        "This report file focuses on CDR3 and is compatible with other repertoire analysis tools, such as VDJTools.",
+    ),
     # Nanostring
     "/nanostring/.rcc": FileDetails(
         "source",

--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -209,12 +209,12 @@ details_dict = {
         "plain text statistics of sorted.bam file alignment",
         "A plain-text file of summary statistics of the alignment. Provides informaion useful for determining sample quality and discovering alignment errors.",
     ),
-    "/rna/analysis/star/.transcriptome.bam": FileDetails(
+    "/rna/analysis/star/transcriptome_bam.bam": FileDetails(
         "miscellaneous",
         "transcriptome bam file",
         "A bam file containing the transcriptomefrom RNAseq expression analyses",
     ),
-    "/rna/analysis/star/.Chimeric.out.junction": FileDetails(
+    "/rna/analysis/star/chimeric_out_junction.junction": FileDetails(
         "miscellaneous",
         "Chimeric junction output",
         "Chimeric junction output for fusion calling",

--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -279,27 +279,27 @@ details_dict = {
         "the log file produced by the Salmon analysis",
         "A plain-text file containing the time and output of all logging by Salmon during sample analysis.",
     ),
-    "/rna/analysis/microbiome/_addSample_report.txt": FileDetails(
+    "/rna/analysis/microbiome/sample_report.txt": FileDetails(
         "miscellaneous",
         "centrifuge summary output file",
         "Centrifuge output file contains name of a genome, taxonomic ID and rank, and also the proportion of this genome normalized by its genomic length",
     ),
-    "/rna/analysis/trust4/_report.tsv": FileDetails(
+    "/rna/analysis/trust4/trust4_report.tsv": FileDetails(
         "miscellaneous",
         "TRUST4 final report file",
         "This report file focuses on CDR3 and is compatible with other repertoire analysis tools, such as VDJTools.",
     ),
-    "/rna/analysis/fusion/fusion_predictions.abridged_addSample.tsv": FileDetails(
+    "/rna/analysis/fusion/fusion_predictions.tsv": FileDetails(
         "miscellaneous",
         "fusion analysis report file",
         "This report file contains valiated fusion gene pairs found in all samples including their gene expression.",
     ),
-    "/rna/analysis/msisensor/single/run_/_msisensor.txt": FileDetails(
+    "/rna/analysis/msisensor/msisensor_report.txt": FileDetails(
         "miscellaneous",
         "msisensor report file",
         "This report file contains MSI score this report file contains MSI score.",
     ),
-    "/rna/analysis/neoantigen/.genotype.json": FileDetails(
+    "/rna/analysis/neoantigen/genotype.json": FileDetails(
         "miscellaneous",
         "arcasHLA report file",
         "This report file contains MHC class I & II HLA alleles.",

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -195,6 +195,10 @@ assay_facets: Facets = {
         ),
         "Microbiome": FacetConfig(["/rna/analysis/microbiome/_addSample_report.txt"]),
         "Immune-Repertoire": FacetConfig(["/rna/analysis/trust4/_report.tsv"]),
+        "Fusion": FacetConfig(
+            ["/rna/analysis/fusion/fusion_predictions.abridged_addSample.tsv"]
+        ),
+        "MSI": FacetConfig(["/rna/analysis/msisensor/single/run_/_msisensor.txt"]),
     },
     "mIF": {
         "Source Images": FacetConfig(

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -169,6 +169,8 @@ assay_facets: Facets = {
                 "/rna/analysis/star/sorted.bam",
                 "/rna/analysis/star/sorted.bam.bai",
                 "/rna/analysis/star/sorted.bam.stat.txt",
+                "/rna/analysis/star/.transcriptome.bam",
+                "/rna/analysis/star/.Chimeric.out.junction",
             ]
         ),
         "Quality": FacetConfig(

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -194,6 +194,7 @@ assay_facets: Facets = {
             ]
         ),
         "Microbiome": FacetConfig(["/rna/analysis/microbiome/_addSample_report.txt"]),
+        "Immune-Repertoire": FacetConfig(["/rna/analysis/trust4/_report.tsv"]),
     },
     "mIF": {
         "Source Images": FacetConfig(

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -193,13 +193,11 @@ assay_facets: Facets = {
                 "/rna/analysis/salmon/salmon_quant.log",
             ]
         ),
-        "Microbiome": FacetConfig(["/rna/analysis/microbiome/_addSample_report.txt"]),
-        "Immune-Repertoire": FacetConfig(["/rna/analysis/trust4/_report.tsv"]),
-        "Fusion": FacetConfig(
-            ["/rna/analysis/fusion/fusion_predictions.abridged_addSample.tsv"]
-        ),
-        "MSI": FacetConfig(["/rna/analysis/msisensor/single/run_/_msisensor.txt"]),
-        "HLA": FacetConfig(["/rna/analysis/neoantigen/.genotype.json"]),
+        "Microbiome": FacetConfig(["/rna/analysis/microbiome/sample_report.txt"]),
+        "Immune-Repertoire": FacetConfig(["/rna/analysis/trust4/trust4_report.tsv"]),
+        "Fusion": FacetConfig(["/rna/analysis/fusion/fusion_predictions.tsv"]),
+        "MSI": FacetConfig(["/rna/analysis/msisensor/msisensor_report.txt"]),
+        "HLA": FacetConfig(["/rna/analysis/neoantigen/genotype.json"]),
     },
     "mIF": {
         "Source Images": FacetConfig(

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -199,6 +199,7 @@ assay_facets: Facets = {
             ["/rna/analysis/fusion/fusion_predictions.abridged_addSample.tsv"]
         ),
         "MSI": FacetConfig(["/rna/analysis/msisensor/single/run_/_msisensor.txt"]),
+        "HLA": FacetConfig(["/rna/analysis/neoantigen/.genotype.json"]),
     },
     "mIF": {
         "Source Images": FacetConfig(

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -169,8 +169,8 @@ assay_facets: Facets = {
                 "/rna/analysis/star/sorted.bam",
                 "/rna/analysis/star/sorted.bam.bai",
                 "/rna/analysis/star/sorted.bam.stat.txt",
-                "/rna/analysis/star/.transcriptome.bam",
-                "/rna/analysis/star/.Chimeric.out.junction",
+                "/rna/analysis/star/transcriptome_bam.bam",
+                "/rna/analysis/star/chimeric_out_junction.junction",
             ]
         ),
         "Quality": FacetConfig(

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -169,14 +169,10 @@ assay_facets: Facets = {
                 "/rna/analysis/star/sorted.bam",
                 "/rna/analysis/star/sorted.bam.bai",
                 "/rna/analysis/star/sorted.bam.stat.txt",
-                "/rna/analysis/star/downsampling.bam",
-                "/rna/analysis/star/downsampling.bam.bai",
             ]
         ),
         "Quality": FacetConfig(
             [
-                "/rna/analysis/rseqc/downsampling_housekeeping.bam",
-                "/rna/analysis/rseqc/downsampling_housekeeping.bam.bai",
                 "/rna/analysis/rseqc/read_distrib.txt",
                 "/rna/analysis/rseqc/tin_score.summary.txt",
                 "/rna/analysis/rseqc/tin_score.txt",

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -193,6 +193,7 @@ assay_facets: Facets = {
                 "/rna/analysis/salmon/salmon_quant.log",
             ]
         ),
+        "Microbiome": FacetConfig(["/rna/analysis/microbiome/_addSample_report.txt"]),
     },
     "mIF": {
         "Source Images": FacetConfig(

--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -5,7 +5,7 @@ sqlalchemy~=1.3.0
 marshmallow-sqlalchemy==0.22.3
 google-cloud-storage~=1.35.0
 google-cloud-pubsub==0.42.1
-cidc-schemas~=0.24.17
+cidc-schemas~=0.24.18
 pandas==0.25.3 # peg for clustergrammer in cloud functions
 python-dotenv==0.10.3
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         "cidc_api.models.files",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.24.18",
+    version="0.24.19",
     zip_safe=False,
 )


### PR DESCRIPTION
Related to RNAseq DM upgrade in https://github.com/CIMAC-CIDC/cidc-schemas/pull/443. 
This PR adds the relevant Facet and File descriptions, and bumps schemas/API versions.