### PR TITLE
Fix how trial listing handles cross-trial permissions

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -1065,10 +1065,17 @@ class TrialMetadata(CommonColumns):
         if trial_ids:
             filters.append(cls.trial_id.in_(trial_ids))
         if not user.is_admin() and not user.is_nci_user():
-            permitted_trials = select([Permissions.trial_id]).where(
-                Permissions.granted_to_user == user.id
-            )
-            filters.append(cls.trial_id.in_(permitted_trials))
+            has_broad_trial_perms = False
+            granular_trial_perms = []
+            for perm in Permissions.find_for_user(user.id):
+                # If perm.trial_id is None, then the user has a cross-trial permission
+                if perm.trial_id is None:
+                    has_broad_trial_perms = True
+                else:
+                    granular_trial_perms.append(perm.trial_id)
+            if not has_broad_trial_perms:
+                filters.append(cls.trial_id.in_(granular_trial_perms))
+
         # possible TODO: filter by assays in a trial
         return lambda q: q.filter(*filters)
 

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -1065,15 +1065,18 @@ class TrialMetadata(CommonColumns):
         if trial_ids:
             filters.append(cls.trial_id.in_(trial_ids))
         if not user.is_admin() and not user.is_nci_user():
-            has_broad_trial_perms = False
+            has_cross_trial_perms = False
             granular_trial_perms = []
             for perm in Permissions.find_for_user(user.id):
                 # If perm.trial_id is None, then the user has a cross-trial permission
                 if perm.trial_id is None:
-                    has_broad_trial_perms = True
+                    has_cross_trial_perms = True
                 else:
                     granular_trial_perms.append(perm.trial_id)
-            if not has_broad_trial_perms:
+            # If the user has a cross-trial permission, then they should be able
+            # to list all trials, so don't include granular permission filters
+            # in that case.
+            if not has_cross_trial_perms:
                 filters.append(cls.trial_id.in_(granular_trial_perms))
 
         # possible TODO: filter by assays in a trial

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -89,7 +89,8 @@ def test_list_trials(cidc_api, clean_db, monkeypatch):
 
     client = cidc_api.test_client()
 
-    # A CIMAC user can list trials that they're allowed to see
+    # A CIMAC user can list trials that they're allowed to see via
+    # granular permissions
     res = client.get("/trial_metadata")
     assert res.status_code == 200
     assert len(res.json["_items"]) == 1
@@ -97,6 +98,15 @@ def test_list_trials(cidc_api, clean_db, monkeypatch):
     assert "file_bundle" not in res.json["_items"][0]
     assert "num_participants" not in res.json["_items"][0]
     assert "num_samples" not in res.json["_items"][0]
+
+    # A CIMAC user with a cross-trial permission can list all trials
+    with cidc_api.app_context():
+        Permissions(
+            granted_by_user=user_id, granted_to_user=user_id, upload_type="ihc"
+        ).insert()
+    res = client.get("/trial_metadata")
+    assert res.status_code == 200
+    assert len(res.json["_items"]) == 2
 
     # Allowed users can get all trials
     for role in trial_modifier_roles:


### PR DESCRIPTION
Currently, permission-based trial filtering doesn't take into account cross-trial permissions (e.g., permission to access Olink data across all trials). This PR updates trial filtering to do so by allowing users who have cross-trial permissions to list all trials.