### PR TITLE
Upgrade staging GAE instance class

### DIFF
--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -1,6 +1,7 @@
 runtime: python37
 env: standard
 entrypoint: gunicorn cidc_api.app:app
+instance_class: F2
 
 handlers:
   # Force HTTPS on all requests


### PR DESCRIPTION
This will give us more memory and a faster CPU on staging.

See: https://cloud.google.com/appengine/docs/standard#instance_classes