### PR TITLE
Enhancement: generate templates on demand, not at startup

### DIFF
--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -1,12 +1,9 @@
 import traceback
-import logging
 
 from flask import Flask, jsonify
 from flask_cors import CORS
 from werkzeug.exceptions import HTTPException
 from marshmallow.exceptions import ValidationError
-
-from cidc_schemas.template import generate_all_templates
 
 from .config.db import init_db
 from .config.settings import SETTINGS
@@ -22,9 +19,6 @@ app.config.update(SETTINGS)
 
 # Enable CORS
 CORS(app, resources={r"*": {"origins": app.config["ALLOWED_CLIENT_URL"]}})
-
-# Generate empty Excel templates
-generate_all_templates(app.config["TEMPLATES_DIR"])
 
 # Set up the database and run the migrations
 init_db(app)

--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -6,7 +6,8 @@ in the `SETTINGS` dictionary defined at the bottom of this file.
 """
 
 import tempfile
-from os import environ, path
+import shutil
+from os import environ, path, mkdir
 
 from dotenv import load_dotenv
 
@@ -29,12 +30,19 @@ ALLOWED_CLIENT_URL = environ.get("ALLOWED_CLIENT_URL")
 IS_GUNICORN = "gunicorn" in environ.get("SERVER_SOFTWARE", "")
 
 ### Configure miscellaneous constants ###
-TEMPLATES_DIR = path.join("/tmp", "templates")
 MIN_CLI_VERSION = "0.9.9"
 PAGINATION_PAGE_SIZE = 25
 MAX_PAGINATION_PAGE_SIZE = 200
 INACTIVE_USER_DAYS = 60
 MAX_THREADPOOL_WORKERS = 32
+TEMPLATES_DIR = path.join("/tmp", "templates")
+# Also, set up the directories for holding generated templates
+if path.exists(TEMPLATES_DIR):
+    shutil.rmtree(TEMPLATES_DIR)
+mkdir(TEMPLATES_DIR)
+for family in ["manifests", "metadata", "analyses"]:
+    family_dir = path.join(TEMPLATES_DIR, family)
+    mkdir(family_dir)
 
 ### Configure prism encrypt ###
 if not TESTING:

--- a/tests/resources/test_info.py
+++ b/tests/resources/test_info.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from datetime import datetime
 
 from cidc_schemas import prism
@@ -126,22 +127,22 @@ def test_templates(cidc_api):
     res = client.get(f"{INFO_ENDPOINT}/templates/foo/bar")
     assert res.status_code == 404
 
-    # Existing manifest
+    # Generate and get a valid manifest
     pbmc_path = os.path.join(
         cidc_api.config["TEMPLATES_DIR"], "manifests", "pbmc_template.xlsx"
     )
-    with open(pbmc_path, "rb") as f:
-        real_pbmc_file = f.read()
+    assert not os.path.exists(pbmc_path)
     res = client.get(f"{INFO_ENDPOINT}/templates/manifests/pbmc")
     assert res.status_code == 200
-    assert res.data == real_pbmc_file
+    with open(pbmc_path, "rb") as f:
+        assert res.data == f.read()
 
-    # Existing assay
+    # Generate and get a valid assay
     olink_path = os.path.join(
         cidc_api.config["TEMPLATES_DIR"], "metadata", "olink_template.xlsx"
     )
-    with open(olink_path, "rb") as f:
-        real_olink_file = f.read()
+    assert not os.path.exists(olink_path)
     res = client.get(f"{INFO_ENDPOINT}/templates/metadata/olink")
     assert res.status_code == 200
-    assert res.data == real_olink_file
+    with open(olink_path, "rb") as f:
+        assert res.data == f.read()


### PR DESCRIPTION
This change reduces app startup times from around `6.8s` to `4.4s` on my computer (N=5), without producing any noticeable performance difference when requesting templates.