### PR TITLE
Fix facet counting and data category display issues

### DIFF
--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -302,27 +302,28 @@ FACET_NAME_DELIM = "|"
 
 
 def _build_facet_groups_to_names():
+    """Map facet_groups to human-readable data categories."""
     path_to_name = lambda path: FACET_NAME_DELIM.join(path)
 
     facet_names = {}
+    for facet_name, subfacet in facets_dict["Assay Type"].items():
+        for subfacet_name, subsubfacet in subfacet.items():
+            for facet_group in subsubfacet.facet_groups:
+                facet_names[facet_group] = path_to_name([facet_name, subfacet_name])
 
-    for facet_type, facet_dict in facets_dict.items():
-        for facet_name, subfacet in facet_dict.items():
-            if isinstance(subfacet, dict):
-                for subfacet_name, subsubfacet in subfacet.items():
-                    for facet_group in subsubfacet.facet_groups:
-                        facet_names[facet_group] = path_to_name(
-                            [facet_name, subfacet_name]
-                        )
+    for facet_name, subfacet in facets_dict["Clinical Type"].items():
+        for facet_group in subfacet.facet_groups:
+            facet_names[facet_group] = path_to_name([facet_name])
 
-            elif isinstance(subfacet, FacetConfig):
-                for facet_group in subfacet.facet_groups:
-                    facet_names[facet_group] = path_to_name([facet_name])
+    # Note on why we don't use "Analysis Ready": any facet group included in the
+    # "Analysis Ready" facet type will also have an entry in "Assay Type".
+    # The "Assay Type" config will yield a more specific data category for
+    # the given facet group, so we skip the "Analysis Ready" config here.
 
     return facet_names
 
 
-facet_groups_to_names = _build_facet_groups_to_names()
+facet_groups_to_categories = _build_facet_groups_to_names()
 
 
 def build_data_category_facets(facet_group_file_counts: Dict[str, int]):

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -1973,10 +1973,10 @@ class DownloadableFiles(CommonColumns):
     def get_data_category_facets(
         cls, session: Session, filter_: Callable[[Query], Query] = lambda q: q
     ):
-        data_category_file_counts = cls.count_by(
-            cls.data_category, session=session, filter_=filter_
+        facet_group_file_counts = cls.count_by(
+            cls.facet_group, session=session, filter_=filter_
         )
-        data_category_facets = build_data_category_facets(data_category_file_counts)
+        data_category_facets = build_data_category_facets(facet_group_file_counts)
         return data_category_facets
 
 

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -54,7 +54,7 @@ from .files import (
     build_trial_facets,
     build_data_category_facets,
     get_facet_groups_for_paths,
-    facet_groups_to_names,
+    facet_groups_to_categories,
     details_dict,
     FilePurpose,
     FACET_NAME_DELIM,
@@ -1617,7 +1617,7 @@ class DownloadableFiles(CommonColumns):
 
     @hybrid_property
     def data_category(self):
-        return facet_groups_to_names.get(self.facet_group)
+        return facet_groups_to_categories.get(self.facet_group)
 
     @data_category.expression
     def data_category(cls):
@@ -1983,7 +1983,10 @@ class DownloadableFiles(CommonColumns):
 # Query clause for computing a downloadable file's data category.
 # Used above in the DownloadableFiles.data_category computed property.
 DATA_CATEGORY_CASE_CLAUSE = case(
-    [(DownloadableFiles.facet_group == k, v) for k, v in facet_groups_to_names.items()]
+    [
+        (DownloadableFiles.facet_group == k, v)
+        for k, v in facet_groups_to_categories.items()
+    ]
 )
 
 # Query clause for computing a downloadable file's file purpose.

--- a/tests/models/files/test_facets.py
+++ b/tests/models/files/test_facets.py
@@ -13,10 +13,12 @@ from cidc_api.models.files.facets import (
 def test_build_data_category_facets():
     """Ensure build_data_category_facets works as expected."""
 
-    wes_count = 5
+    wes_count_1 = 2
+    wes_count_2 = 3
     sample_count = 12
     facet_group_file_counts = {
-        "/wes/r1_L.fastq.gz": wes_count,
+        "/wes/r1_L.fastq.gz": wes_count_1,
+        "/wes/analysis/report.tar.gz": wes_count_2,
         "csv|samples info": sample_count,
     }
 
@@ -35,7 +37,9 @@ def test_build_data_category_facets():
                 if isinstance(subvalue, list):
                     for config in subvalue:
                         if value_key == "WES" and config["label"] == "Source":
-                            assert_expected_facet_structure(config, wes_count)
+                            assert_expected_facet_structure(
+                                config, wes_count_1 + wes_count_2
+                            )
                         else:
                             assert_expected_facet_structure(config)
                 elif isinstance(subvalue, dict):

--- a/tests/models/files/test_facets.py
+++ b/tests/models/files/test_facets.py
@@ -37,9 +37,9 @@ def test_build_data_category_facets():
                 if isinstance(subvalue, list):
                     for config in subvalue:
                         if value_key == "WES" and config["label"] == "Source":
-                            assert_expected_facet_structure(
-                                config, wes_count_1 + wes_count_2
-                            )
+                            assert_expected_facet_structure(config, wes_count_1)
+                        elif value_key == "WES" and config["label"] == "Report":
+                            assert_expected_facet_structure(config, wes_count_2)
                         else:
                             assert_expected_facet_structure(config)
                 elif isinstance(subvalue, dict):
@@ -50,6 +50,8 @@ def test_build_data_category_facets():
             for config in value:
                 if config["label"] == "Samples Info":
                     assert_expected_facet_structure(config, sample_count)
+                elif config["label"] == "WES":  # Analysis-ready facet
+                    assert_expected_facet_structure(config, wes_count_2)
                 else:
                     assert_expected_facet_structure(config)
 

--- a/tests/models/files/test_facets.py
+++ b/tests/models/files/test_facets.py
@@ -15,15 +15,19 @@ def test_build_data_category_facets():
 
     wes_count = 5
     sample_count = 12
-    data_category_file_counts = {"WES|Source": wes_count, "Samples Info": sample_count}
+    facet_group_file_counts = {
+        "/wes/r1_L.fastq.gz": wes_count,
+        "csv|samples info": sample_count,
+    }
 
     def assert_expected_facet_structure(config: dict, count: int = 0):
         assert "label" in config
         assert "description" in config
         assert config["count"] == count
 
-    facet_specs = build_data_category_facets(data_category_file_counts)
+    facet_specs = build_data_category_facets(facet_group_file_counts)
     print(facet_specs)
+
     for value in facet_specs.values():
         if isinstance(value, dict):
             for value_key, subvalue in value.items():

--- a/tests/models/files/test_facets.py
+++ b/tests/models/files/test_facets.py
@@ -70,9 +70,9 @@ def test_get_facet_groups_for_paths():
     ]
     facets_for_paths = get_facet_groups_for_paths(good_paths)
     assert facets_for_paths == [
-        *facets_dict["Assay Type"]["WES"]["Somatic"].match_clauses,
-        *facets_dict["Assay Type"]["RNA"]["Quality"].match_clauses,
-        *facets_dict["Clinical Type"]["Participants Info"].match_clauses,
+        *facets_dict["Assay Type"]["WES"]["Somatic"].facet_groups,
+        *facets_dict["Assay Type"]["RNA"]["Quality"].facet_groups,
+        *facets_dict["Clinical Type"]["Participants Info"].facet_groups,
     ]
 
     # Non-existent paths


### PR DESCRIPTION
Currently, the facet file counts on the portal don't matching up with the number of files that selecting that facet returns. This issue stems from the way the existing facet file counting works: it counts files by data category (a single value derived from a facet group's location in the facet hierarchy) rather than by facet group directly, and our data category implementation can't handle facet groups that belong to more than one `FacetConfig` (as is the case for facet groups that appear under both `"Assay Type"` and `"Analysis Ready"`).

Per @scvannost's insight, counting files by facet group directly solves this issue.