### PR TITLE
Separate facet for TCR report

### DIFF
--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -636,8 +636,8 @@ details_dict = {
     "/tcr/replicate_/i2.fastq.gz": FileDetails("source", "", ""),
     "/tcr/SampleSheet.csv": FileDetails("miscellaneous", "", ""),
     "/tcr_analysis/summary_info.csv": FileDetails("miscellaneous", "", ""),
-    "/tcr_analysis/tra_clone.csv": FileDetails("miscellaneous", "", ""),
-    "/tcr_analysis/trb_clone.csv": FileDetails("miscellaneous", "", ""),
+    "/tcr_analysis/tra_clone.csv": FileDetails("analysis", "", ""),
+    "/tcr_analysis/trb_clone.csv": FileDetails("analysis", "", ""),
     "/tcr_analysis/report_trial.tar.gz": FileDetails("analysis", "", ""),
     # H&E
     "/hande/image_file.svs": FileDetails(

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -386,17 +386,11 @@ assay_facets: Facets = {
         ),
         "Misc.": FacetConfig(["/tcr/SampleSheet.csv" "/tcr_analysis/summary_info.csv"]),
         "Analysis Data": FacetConfig(
-            [
-                "/tcr_analysis/tra_clone.csv",
-                "/tcr_analysis/trb_clone.csv",
-            ],
+            ["/tcr_analysis/tra_clone.csv", "/tcr_analysis/trb_clone.csv",],
             "Data files indicating TRA & TRB clones' UMI counts",
         ),
         "Reports": FacetConfig(
-            [
-                "/tcr_analysis/report_trial.tar.gz",
-            ],
-            "Report from TCRseq analysis",
+            ["/tcr_analysis/report_trial.tar.gz",], "Report from TCRseq analysis",
         ),
     },
     "ELISA": {"Data": FacetConfig(["/elisa/assay.xlsx"])},

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -389,9 +389,14 @@ assay_facets: Facets = {
             [
                 "/tcr_analysis/tra_clone.csv",
                 "/tcr_analysis/trb_clone.csv",
+            ],
+            "Data files indicating TRA & TRB clones' UMI counts",
+        ),
+        "Reports": FacetConfig(
+            [
                 "/tcr_analysis/report_trial.tar.gz",
             ],
-            "Data files and Report from TCRseq analysis indicating TRA & TRB clones' UMI counts",
+            "Report from TCRseq analysis",
         ),
     },
     "ELISA": {"Data": FacetConfig(["/elisa/assay.xlsx"])},


### PR DESCRIPTION
This PR moves the TCR reports to a separate facet than the other analysis files.