### PR TITLE
Update Data Access Report to list cross-trail on every tab

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -421,11 +421,12 @@ class Users(CommonColumns):
         ).fillna("*")
 
         with pd.ExcelWriter(io) as writer:
-            for trial_id, trial_group in df.groupby("trial_id"):
-                if trial_id != "*":
-                    trial_group.to_excel(writer, sheet_name=trial_id, index=False)
-                else:
-                    trial_group.to_excel(writer, sheet_name="--all--", index=False)
+            for trial_id in df["trial_id"].unique():
+                if trial_id == "*":
+                    continue
+
+                trial_group = df[(df["trial_id"] == trial_id) | (df["trial_id"] == "*")]
+                trial_group.to_excel(writer, sheet_name=trial_id, index=False)
 
         return df
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -1,4 +1,5 @@
 from jsonschema.validators import validate
+import pandas as pd
 from cidc_api.models.schemas import TrialMetadataListSchema
 import io
 import logging
@@ -1405,24 +1406,34 @@ def test_user_get_data_access_report(clean_db, monkeypatch):
         ["email", "role", "organization", "trial_id", "permissions"]
     )
     for t in [trial, trial2]:
+        trial_df = pd.read_excel(bio, t.trial_id)
         for user in [admin_user, cimac_user]:
-            user_df = result_df[result_df.trial_id == t.trial_id][
-                result_df.email == user.email
-            ]
+            user_df = trial_df[trial_df.email == user.email]
             assert set([user.role]) == set(user_df.role)
             assert set([user.organization]) == set(user_df.organization)
             if user == admin_user:
+                #  trial_id  permissions
+                # ----------------------
+                # {trial_id}      *
                 assert set(["*"]) == set(user_df.permissions)
-            else:
+            else:  # user == cimac_user
                 if t == trial:
+                    #  trial_id   permissions
+                    # ------------------------
+                    # {trial_id} "wes_bam,ihc" < or reverse
+                    #      *       "olink"
                     assert set(user_df.permissions).issubset(
-                        ["wes_bam,ihc", "ihc,wes_bam"]
+                        ["wes_bam,ihc", "ihc,wes_bam", "olink"]
                     )
-                else:
-                    assert set(["*"]) == set(user_df.permissions)
-
-    assert set(
-        result_df[result_df.trial_id == "*"][
-            result_df.email == cimac_user.email
-        ].permissions
-    ) == set(["olink"])
+                else:  # t == trial2
+                    #  trial_id  permissions
+                    # ----------------------
+                    # {trial_id}      *
+                    #      *       "olink"
+                    assert len(user_df.index) == 2
+                    assert (
+                        user_df.permissions[user_df.trial_id == t.trial_id] == "*"
+                    ).all()
+                    assert (
+                        user_df.permissions[user_df.trial_id != t.trial_id] == "olink"
+                    ).all()


### PR DESCRIPTION
instead of single --all-- tab
also test the report itself directly instead of the df used to build it