### PR TITLE
CIDC-1130 schemas bump: flatten TCR, add tcr_adaptive, template tweaks

### DIFF
--- a/requirements.modules.txt
+++ b/requirements.modules.txt
@@ -12,4 +12,4 @@ typing_extensions~=3.7.4
 # pin jinja version to resolve cidc-schemas dependency issue
 jinja2==2.10.3
 
-cidc-schemas~=0.25.8
+cidc-schemas~=0.25.12

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         "cidc_api.models.files",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.8",
+    version="0.25.9",
     zip_safe=False,
 )


### PR DESCRIPTION
## What

Bump schemas requirement to most version.
[schemas changes](https://github.com/CIMAC-CIDC/cidc-schemas/compare/3d4d63f7d4fa4f1272c2be99553063aa7df3d97b..adaptive)

## Why

[CIDC-1130](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1130)
equivalent: https://github.com/CIMAC-CIDC/cidc-schemas/pull/499

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
