### PR TITLE
CIDC-1130 add facet definitions for new TCR tsv's

### DIFF
--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -672,6 +672,8 @@ details_dict = {
         "source", "Unharmonized, one-off, or not-yet-supported data.", ""
     ),
     # TCR
+    "/tcr/reads.tsv": FileDetails("source", "", ""),
+    "/tcr/controls/reads.tsv": FileDetails("source", "", ""),
     "/tcr/replicate_/r1.fastq.gz": FileDetails("source", "", ""),
     "/tcr/replicate_/r2.fastq.gz": FileDetails("source", "", ""),
     "/tcr/replicate_/i1.fastq.gz": FileDetails("source", "", ""),

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -380,6 +380,8 @@ assay_facets: Facets = {
     "TCR": {
         "Source": FacetConfig(
             [
+                "/tcr/reads.tsv",
+                "/tcr/controls/reads.tsv",
                 "/tcr/replicate_/r1.fastq.gz",
                 "/tcr/replicate_/r2.fastq.gz",
                 "/tcr/replicate_/i1.fastq.gz",

--- a/cidc_api/resources/admin.py
+++ b/cidc_api/resources/admin.py
@@ -18,7 +18,7 @@ def test_csms():
 def load_from_blobs():
     errors = syncall_from_blobs()
     if len(errors):
-        res = jsonify(errors=errors)
+        res = jsonify(errors=[str(e) for e in errors])
         res.status_code = 500
         return res
     else:


### PR DESCRIPTION
## What

Prod deploy to add the facets for the new TCR reads.tsv added for Adaptive

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
