### PR TITLE
CIDC-1142 add WES TWIST enum values to relational db; tweak error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 This Changelog tracks changes to this project. The notes below include a summary for each release, followed by details which contain one or more of the following tags:
+
 - `added` for new features.
 - `changed` for functionality and API changes.
 - `deprecated` for soon-to-be removed features.
@@ -8,13 +9,34 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.13` - 23 Sept 2021
+
+- `added` added TWIST enum values to WES in relational tables
+
+## Version `0.25.12` - 23 Sept 2021
+
+- `added` schemas bump to add TWIST enum values to WES in JSON
+
+## Version `0.25.11` - 22 Sept 2021
+
+- `added` module export for models.templates
+
+## Version `0.25.10` - 22 Sept 2021
+
+- `changed` schemas bump to add TCRseq controls
+
+## Version `0.25.9` - 22 Sept 2021
+
+- `changed` schemas bump for new TCRseq Adaptive template
 
 ## Version `0.25.8` - 08 Sept 2021
 
 ### Summary
+
 Initial set up of tables and definition of needed classes for base metadata and assay uploads. Generated new-style templates and added full testing data for pbmc, tissue_slide, h_and_e, wes_<fastq/bam>; demo for clinical_data. Implemented JSON -> Relational sync function and wired for testing. Added relational hooks into existing manifest and assay/analysis uploads. Added way to trigger initial synchronization. Allows relational ClinicalTrials to be edited along with TrialMetadatas from the admin panel.
 
 ### Details
+
 - `added` JIRA integration ([#564](https://github.com/CIMAC-CIDC/cidc-api-gae/pull/564))
 - `added` `changed` Step 1 of Relational DB towards CSMS Integration ([#549](https://github.com/CIMAC-CIDC/cidc-api-gae/pull/549/))
 - `added` Add logging to syncall_from_blobs ([#565](https://github.com/CIMAC-CIDC/cidc-api-gae/pull/565))

--- a/cidc_api/models/templates/assay_metadata.py
+++ b/cidc_api/models/templates/assay_metadata.py
@@ -119,6 +119,7 @@ class WESUpload(NGSUpload):
         Enum(
             "Express Somatic Human WES (Deep Coverage) v1.1",
             "Somatic Human WES v6",
+            "TWIST",
             name="sequencing_protocol_enum",
         ),
         doc="Protocol and version used for the sequencing.",
@@ -128,6 +129,7 @@ class WESUpload(NGSUpload):
             "whole_exome_illumina_coding_v1",
             "broad_custom_exome_v1",
             "TWIST Dana Farber Custom Panel",
+            "TWIST Custom Panel PN 101042",
             name="bait_set_enum",
         ),
         nullable=False,

--- a/cidc_api/models/templates/file_metadata.py
+++ b/cidc_api/models/templates/file_metadata.py
@@ -61,6 +61,9 @@ ArtifactCategory = Enum(
     "Manifest File",
     name="artifact_category_enum",
 )
+AssayCreator = Enum(
+    "DFCI", "Mount Sinai", "Stanford", "MD Anderson", "TWIST", name="assay_creator_enum"
+)
 UploadStatus = Enum(
     "started",
     "upload-completed",
@@ -121,7 +124,7 @@ class Upload(MetadataModel):
         doc="The type of upload (pbmc, wes, olink, wes_analysis, ...)",
     )
     assay_creator = Column(
-        ArtifactCreator, nullable=False, doc="Which CIMAC site created the data"
+        AssayCreator, nullable=False, doc="Which CIMAC site created the data"
     )
     uploader_email = Column(
         String,

--- a/cidc_api/models/templates/utils.py
+++ b/cidc_api/models/templates/utils.py
@@ -105,6 +105,9 @@ def _get_global_insertion_order() -> List[MetadataModel]:
 
 
 def _handle_postgres_error(error: IntegrityError, model: Type) -> Exception:
+    if not hasattr(error, "orig"):
+        return error
+
     orig = error.orig
     pg_error: str = orig.pgerror
     instance = {c.name: v for c, v in model(**error.params).primary_key_map().items()}
@@ -207,17 +210,22 @@ def insert_record_batch(
                 errors.append(_handle_postgres_error(e, model))
                 break
 
-        # flush these records to generate db-derived values
-        # in case they're needed for later fk's
-        try:
-            session.flush()
-        except (DataError, IntegrityError) as e:
-            errors.append(_handle_postgres_error(e, model=model))
-            break  # if it fails in a flush, it's done done
+        if len(errors) != 0:  # if we've hit an error, we're done
+            break
+        else:
+            # flush these records to generate db-derived values
+            # in case they're needed for later fk's
+            try:
+                session.flush()
+            except (DataError, IntegrityError) as e:
+                errors.append(_handle_postgres_error(e, model=model))
+                break  # if it fails in a flush, it's done done
 
-    if hold_commit:
+    if len(errors):
+        session.rollback()
+    elif hold_commit:
         session.flush()
-    elif dry_run or len(errors):
+    elif dry_run:
         session.rollback()
     else:
         session.commit()

--- a/migrations/versions/a90dd4593e54_add_file_and_upload.py
+++ b/migrations/versions/a90dd4593e54_add_file_and_upload.py
@@ -28,7 +28,7 @@ def upgrade():
     sa.Column('gcs_file_map', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
     sa.Column('gcs_xlsx_uri', sa.String(), nullable=True),
     sa.Column('upload_type', sa.String(), nullable=False),
-    sa.Column('assay_creator', sa.Enum('DFCI', 'Mount Sinai', 'Stanford', 'MD Anderson', name='artifact_creator_enum'), nullable=False),
+    sa.Column('assay_creator', sa.Enum('DFCI', 'Mount Sinai', 'Stanford', 'MD Anderson', 'TWIST', name='assay_creator_enum'), nullable=False),
     sa.Column('uploader_email', sa.String(), nullable=False),
     sa.ForeignKeyConstraint(['trial_id'], ['clinical_trials.protocol_identifier'], ),
     sa.ForeignKeyConstraint(['uploader_email'], ['users.email'], ),

--- a/migrations/versions/cf67f9b91d10_.py
+++ b/migrations/versions/cf67f9b91d10_.py
@@ -24,7 +24,7 @@ def upgrade():
     op.create_table('ngs_uploads',
     sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
     sa.Column('trial_id', sa.String(), nullable=False),
-    sa.Column('sequencer_platform', sa.Enum('Illumina - HiSeq 2500', 'Illumina - HiSeq 3000', 'Illumina - NextSeq 550', 'Illumina - HiSeq 4000', 'Illumina - NovaSeq 6000', 'MiSeq', name='sequencer_platform_enum'), nullable=True),
+    sa.Column('sequencer_platform', sa.Enum('Illumina - HiSeq 2500', 'Illumina - HiSeq 3000', 'Illumina - NextSeq 550', 'Illumina - HiSeq 4000', 'Illumina - NovaSeq 6000', 'MiSeq', 'TWIST', name='sequencer_platform_enum'), nullable=True),
     sa.Column('library_kit', sa.Enum('Hyper Prep ICE Exome Express: 1.0', 'KAPA HyperPrep', 'IDT duplex UMI adapters', 'TWIST', name='library_kit_enum'), nullable=True),
     sa.Column('paired_end_reads', sa.Enum('Paired', 'Single', name='paired_end_reads_enum'), nullable=True),
     sa.ForeignKeyConstraint(['id', 'trial_id'], ['uploads.id', 'uploads.trial_id'], ),
@@ -34,7 +34,7 @@ def upgrade():
     sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
     sa.Column('trial_id', sa.String(), nullable=False),
     sa.Column('sequencing_protocol', sa.Enum('Express Somatic Human WES (Deep Coverage) v1.1', 'Somatic Human WES v6', name='sequencing_protocol_enum'), nullable=True),
-    sa.Column('bait_set', sa.Enum('whole_exome_illumina_coding_v1', 'broad_custom_exome_v1', 'TWIST Dana Farber Custom Panel', name='bait_set_enum'), nullable=False),
+    sa.Column('bait_set', sa.Enum('whole_exome_illumina_coding_v1', 'broad_custom_exome_v1', 'TWIST Dana Farber Custom Panel', 'TWIST Custom Panel PN 101042', name='bait_set_enum'), nullable=False),
     sa.Column('read_length', sa.Integer(), nullable=False),
     sa.ForeignKeyConstraint(['id', 'trial_id'], ['ngs_uploads.id', 'ngs_uploads.trial_id'], ),
     sa.PrimaryKeyConstraint('id', 'trial_id')

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.12",
+    version="0.25.13",
     zip_safe=False,
 )


### PR DESCRIPTION
## What

Add the same values that were added in https://github.com/CIMAC-CIDC/cidc-schemas/pull/501 to the relational tables by updating the migrations.
Additionally, improve error handling to directly log actual errors.

## Why

When testing the schemas update to WES for TWIST, discovered that I forgot to add them to the relational tables.
Also discovered in the logs that some errors were not being caught and handled correctly for logging.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
