### PR TITLE
Disable abstract-class-instantiated pylint error

### DIFF
--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -427,7 +427,7 @@ class Users(CommonColumns):
             query, columns=["email", "organization", "role", "trial_id", "permissions"]
         ).fillna("*")
 
-        with pd.ExcelWriter(io) as writer:
+        with pd.ExcelWriter(io) as writer: # https://github.com/PyCQA/pylint/issues/3060 pylint: disable=abstract-class-instantiated
             for trial_id in df["trial_id"].unique():
                 if trial_id == "*":
                     continue


### PR DESCRIPTION
## What

Pylint currently throws a (false) abstract-class-instantiated error with [pandas.ExcelWriter](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/models/models.py#L430).

## Why
```Abstract class 'ExcelWriter' with abstract methods instantiated```

## How

[This comment](https://github.com/PyCQA/pylint/issues/3060#issuecomment-524706708) temporarily disables it.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
