### PR TITLE
CIDC-1148 capture returns from utils

### DIFF
--- a/tests/csms/utils.py
+++ b/tests/csms/utils.py
@@ -59,6 +59,8 @@ def samples_history(cimac_id: str) -> Dict[str, Any]:
             }
         )
 
+    return ret
+
 
 def manifests_history(manifest_id: str) -> Dict[str, Any]:
     """Return the history for a manifest with a given ID"""
@@ -97,6 +99,8 @@ def manifests_history(manifest_id: str) -> Dict[str, Any]:
                 },
             }
         )
+
+    return ret
 
 
 @with_default_session


### PR DESCRIPTION
## What

Captures missing returns.

## Why

To ensure function [samples_history()](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/tests/csms/utils.py#L307) and [manifests_history()](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/tests/csms/utils.py#L310) are returning values that can actually be assigned during testing.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
