### PR TITLE
CIDC-1135 change CSMS URLs to pull from secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## Version `0.25.18` - this
+## Version `0.25.19` - this
+
+- `changed` CSMS_BASE_URL and CSMS_TOKEN_URL to be pulled from secrets
+
+## Version `0.25.18` - 14 Oct 2021
 
 - `fixed` changed prefix generator to correctly handle prefixes without regex support
 

--- a/app.prod.yaml
+++ b/app.prod.yaml
@@ -41,5 +41,3 @@ env_variables:
   GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
   GOOGLE_UPLOAD_ROLE: "projects/cidc-dfci/roles/objectUploader"
   GOOGLE_LISTER_ROLE: "projects/cidc-dfci/roles/CustomRoleLister"
-  CSMS_BASE_URL: "https://csms-api.nci.nih.gov/api/v1/cimac"
-  CSMS_TOKEN_URL: "https://bioappdev.okta.com/oauth2/aus4e9y48iy1kwRUS297/v1/token"

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -33,5 +33,3 @@ env_variables:
   GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
   GOOGLE_UPLOAD_ROLE: "projects/cidc-dfci-staging/roles/objectUploader"
   GOOGLE_LISTER_ROLE: "projects/cidc-dfci-staging/roles/CustomRoleLister"
-  CSMS_BASE_URL: "https://csms-api-uat.nci.nih.gov/api/v1/cimac"
-  CSMS_TOKEN_URL: "https://bioappdev.okta.com/oauth2/aus3urx1v0ilXZ6ud297/v1/token"

--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -113,13 +113,15 @@ this_directory = path.dirname(path.abspath(__file__))
 MIGRATIONS_PATH = path.join(this_directory, "..", "..", "migrations")
 
 # CSMS Integration Values
-CSMS_BASE_URL = environ.get("CSMS_BASE_URL")
-CSMS_TOKEN_URL = environ.get("CSMS_TOKEN_URL")
 if not TESTING:
     secret_manager = get_secrets_manager()
+    CSMS_BASE_URL = secret_manager.get("CSMS_BASE_URL")
+    CSMS_TOKEN_URL = secret_manager.get("CSMS_TOKEN_URL")
     CSMS_CLIENT_SECRET = secret_manager.get("CSMS_CLIENT_SECRET")
     CSMS_CLIENT_ID = secret_manager.get("CSMS_CLIENT_ID")
 else:
+    CSMS_BASE_URL = environ.get("CSMS_BASE_URL")
+    CSMS_TOKEN_URL = environ.get("CSMS_TOKEN_URL")
     CSMS_CLIENT_SECRET = environ.get("CSMS_CLIENT_SECRET")
     CSMS_CLIENT_ID = environ.get("CSMS_CLIENT_ID")
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.18",
+    version="0.25.19",
     zip_safe=False,
 )


### PR DESCRIPTION
## What

Changes the source of CSMS urls to draw from the secrets buckets instead of the app configuration stored within the repository. Staging secrets resources should be created before this PR is merged, and production ones should be created before prod deploy.

## Why & How

[CIDC-1135](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1135) requires us to run a test on staging while referring to CSMS production. @jim-bo suggested this variable should be configurable, which is straight-forward to do by using the secrets logic we already have.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
