### PR TITLE
CIDC-1162 handle old-style permissions when popping a binding

### DIFF
--- a/cidc_api/shared/gcloud_client.py
+++ b/cidc_api/shared/gcloud_client.py
@@ -695,13 +695,21 @@ def _find_and_pop_binding(
         )
     )
 
-    # if it's an expiring permission, it'll be in the form (prefix or prefix2) and time
+    # if it's an expiring permission, it'll be in the form: (prefix or prefix2) and time
+    # # old permissions are in the form: time and prefix
     prefix_conditions = (
         binding.get("condition", {}).get("expression", "") if binding else ""
     )
     if GOOGLE_AND_OPERATOR in prefix_conditions:
         # clean up parentheses
-        prefix_conditions = prefix_conditions.split(GOOGLE_AND_OPERATOR)[0][1:-1]
+        prefix_conditions = prefix_conditions.split(GOOGLE_AND_OPERATOR)
+        if "resource.name.startsWith" in prefix_conditions[1]:
+            # old-style: time and prefix
+            prefix_conditions = prefix_conditions[1]
+        else:
+            # (prefix or prefix2) and time
+            prefix_conditions = prefix_conditions[0].strip("()")
+
     remaining_conditions = [
         condition
         for condition in prefix_conditions.split(GOOGLE_OR_OPERATOR)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.20",
+    version="0.25.21",
     zip_safe=False,
 )


### PR DESCRIPTION
## What

Handle old-style permissions that are in the form `request.time < timestamp("yyyy-mm-ddThh:mm:ssZ") && resource.name.startsWith("projects/_/buckets/<bucket>/objects/<prefix>")`
as well as the new style `( resource.name.startsWith("projects/_/buckets/<bucket>/objects/<prefix1>") || resource.name.startsWith("projects/_/buckets/<bucket>/objects/<prefix2>") ) && request.time < timestamp("yyyy-mm-ddThh:mm:ssZ")`

## Why

In testing https://github.com/CIMAC-CIDC/cidc-api-gae/pull/591 for [CIDC-1157](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1157) and https://github.com/CIMAC-CIDC/cidc-api-gae/pull/590/files for [CIDC-1162](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1162), discovered that removing old permissions causes errors in `storage.setIamPermissions`.

## How

Look at each half of the conditions after splitting on `&&` to decide if it is a new- or old-style permission and pull out the prefix conditions correctly.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
