### PR TITLE
CIDC-1134 CSMS patch: pass limit and offset as params to requests.get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## Version `0.25.19` - this
+## Version `0.25.22` - 21 Oct 2021
+
+- `fixed` pass limit and offset as params instead of kwargs to requests.get
+
+## Version `0.25.21` - 19 Oct 2021
+
+- `added` handling to remove old-style permissions
+
+## Version `0.25.20` - 19 Oct 2021
+
+- `added` logging to set_iam_policy errors
+
+## Version `0.25.19` - 15 Oct 2021
 
 - `changed` CSMS_BASE_URL and CSMS_TOKEN_URL to be pulled from secrets
 

--- a/cidc_api/csms/auth.py
+++ b/cidc_api/csms/auth.py
@@ -83,8 +83,9 @@ def get_with_paging(
             limit = 5000
         elif "manifests" in url:
             limit = 50
+    kwargs.update(dict(limit=limit, offset=offset))
 
-    res = get_with_authorization(url, limit=limit, offset=offset, **kwargs)
+    res = get_with_authorization(url, params=kwargs)
     while res.status_code < 300 and len(res.json().get("data", [])) > 0:
         # if there's not an error and we're still returning
         yield from res.json()["data"]

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.21",
+    version="0.25.22",
     zip_safe=False,
 )


### PR DESCRIPTION
## Why

Discovered in testing. Incorrect call not checked by test mocking.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
