### PR TITLE
CIDC-1134 correct second call to get_with_authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.25` - 22 Oct 2021
+
+- `fixed` second call to get_with_authorization
+
+## Version `0.25.24` - 22 Oct 2021
+
+- `changed` schemas bump for mIF QC report
+
 ## Version `0.25.23` - 21 Oct 2021
 
 - `changed` moved validation of trial's existing in the JSON blobs to better reflect name and usage

--- a/cidc_api/csms/auth.py
+++ b/cidc_api/csms/auth.py
@@ -90,6 +90,6 @@ def get_with_paging(
         # if there's not an error and we're still returning
         yield from res.json()["data"]
         offset += 1  # get the next page
-        res = get_with_authorization(url, limit=limit, offset=offset, **kwargs)
+        res = get_with_authorization(url, **kwargs)
     else:
         res.raise_for_status()

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.24",
+    version="0.25.25",
     zip_safe=False,
 )


### PR DESCRIPTION
## What

Correct second call to get_with_authorization -- limit and offset were getting passed twice.

## Why

Discovered in testing.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
