### PR TITLE
CIDC-1134 update CSMS test manifest data to not provide protocol_identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.28` - 26 Oct 2021
+
+- `remove` incorrect accessing of CSMS manifest protocol_identifier which is only stored on the samples
+
+## Version `0.25.27` - 25 Oct 2021
+
+- `added` facets and file details for mIF report file
+- `remove` Templates facet entirely
+
 ## Version `0.25.26` - 22 Oct 2021
 
 - `fixed` second call to get_with_authorization again

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.27",
+    version="0.25.28",
     zip_safe=False,
 )

--- a/tests/csms/data.py
+++ b/tests/csms/data.py
@@ -634,7 +634,6 @@ manifests = [
         "courier": "Inter-Site Delivery",
         "date_received": "2021-01-05 00:00:00",
         "date_shipped": "2021-01-03 00:00:00",
-        "protocol_identifier": "test_trial",
         "quality_of_shipment": "Specimen shipment received in good condition",
         "receiving_party": "Adaptive",
         "ship_from": "from",

--- a/tests/models/templates/test_csms_api.py
+++ b/tests/models/templates/test_csms_api.py
@@ -172,7 +172,6 @@ def test_manifest_non_critical_changes(cidc_api, clean_db, monkeypatch):
                     "manifest_id",
                     "modified_time",
                     "modified_timestamp",
-                    "protocol_identifier",
                     "samples",
                     "status",
                     "submitter",
@@ -197,7 +196,7 @@ def test_manifest_non_critical_changes(cidc_api, clean_db, monkeypatch):
                 assert len(changes) == 1 and changes[0] == Change(
                     entity_type="shipment",
                     manifest_id=manifest["manifest_id"],
-                    trial_id=manifest["protocol_identifier"],
+                    trial_id=manifest["samples"][0]["protocol_identifier"],
                     changes={
                         key: (
                             datetime.strptime(manifest[key], "%Y-%m-%d %H:%M:%S").date()
@@ -229,7 +228,6 @@ def test_manifest_non_critical_changes_on_samples(cidc_api, clean_db, monkeypatc
                     "manifest_id",
                     "modified_time",
                     "modified_timestamp",
-                    "protocol_identifier",
                     "samples",
                     "status",
                     "submitter",
@@ -280,7 +278,7 @@ def test_manifest_non_critical_changes_on_samples(cidc_api, clean_db, monkeypatc
                     assert len(changes) == 1 and changes[0] == Change(
                         entity_type="shipment",
                         manifest_id=manifest["manifest_id"],
-                        trial_id=manifest["protocol_identifier"],
+                        trial_id=manifest["samples"][0]["protocol_identifier"],
                         changes={key: (manifest["samples"][0][key], "foo"),},
                     ), str(changes)
 
@@ -384,9 +382,9 @@ def test_sample_non_critical_changes(cidc_api, clean_db, monkeypatch):
 
                 assert len(changes) == 1 and changes[0] == Change(
                     entity_type="sample",
-                    trial_id=manifest["protocol_identifier"],
                     manifest_id=manifest["manifest_id"],
                     cimac_id=manifest["samples"][0]["cimac_id"],
+                    trial_id=manifest["samples"][0]["protocol_identifier"],
                     changes={
                         key: (
                             manifest["samples"][0][key],


### PR DESCRIPTION
## What & Why

Discovered in testing, direct call to manifest["protocol_identifier"] was failing on actual CSMS but not test data. This is because test data provided this while the actual CSMS data does not, so removed that from test data and fixed tests to match.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
