### PR TITLE
CIDC-1134 currently pass session around in CSMS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.29` - 26 Oct 2021
+
+- `fixed` correctly pass session throughout models/templates/csms_api
+
 ## Version `0.25.28` - 26 Oct 2021
 
 - `remove` incorrect accessing of CSMS manifest protocol_identifier which is only stored on the samples

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.28",
+    version="0.25.29",
     zip_safe=False,
 )


### PR DESCRIPTION
## What

Pass the correct session around in the new CSMS API.

## Why

Discovered in testing, fails when called without session passing from CFn.

## How

Checked all uses of `session` in `models/templates/model_core.py`, `models/models.py`, and `models/templates/csms_api.py` and all functions that have calls to it, and so forth.

## Remarks

Unsure how to test that the correct session is being passed everywhere given the currently testing setup.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
