### PR TITLE
CIDC-1069 add summary subquery for ATACseq analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.32` - 27 Oct 2021
+
+- `added` subquery for counting ATACseq analysis to get_summaries for Data Overview dashboard
+
+## Version `0.25.31` - 27 Oct 2021
+
+- `changed` bump schemas version for ATACseq analysis updates
+
+## Version `0.25.30` - 27 Oct 2021
+
+- `fixed` set os environ TZ = UTC before datetime is imported every time
+
 ## Version `0.25.29` - 26 Oct 2021
 
 - `fixed` correctly pass session throughout models/templates/csms_api

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -1426,6 +1426,16 @@ class TrialMetadata(CommonColumns):
                 jsonb_array_elements(batch->'records') record
         """
 
+        atacseq_analysis_subquery = """
+            select
+                trial_id,
+                'atacseq_analysis' as key,
+                jsonb_array_length(batch->'records') as value
+            from
+                trial_metadata,
+                jsonb_array_elements(metadata_json#>'{analysis,atacseq_analysis}') batch
+        """
+
         # Build up a JSON object mapping analysis types to arrays of excluded samples.
         # The resulting object will have structure like:
         # {
@@ -1540,6 +1550,8 @@ class TrialMetadata(CommonColumns):
                     {tcr_analysis_subquery}
                     union all
                     {cytof_analysis_subquery}
+                    union all
+                    {atacseq_analysis_subquery}
                 ) q
                 group by trial_id, key
             ) sample_summaries

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.31",
+    version="0.25.32",
     zip_safe=False,
 )

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -434,6 +434,7 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
         "participants": [{"samples": [1, 2]}, {"samples": [3]}],
         "expected_assays": ["ihc", "olink"],
         "assays": {
+            "atacseq": [{"records": records * 13}],
             "wes": [
                 {"records": records * 6},
                 {"records": records * 5},
@@ -452,6 +453,7 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
             "hande": [{"records": records * 5}],
         },
         "analysis": {
+            "atacseq_analysis": [{"records": records * 12}],
             "wes_analysis": {
                 "pair_runs": [
                     # 7 here for wes_assay: t0/1/2, n0/1/2/3
@@ -551,6 +553,8 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
         [
             {
                 "expected_assays": [],
+                "atacseq": 0.0,
+                "atacseq_analysis": 0.0,
                 "cytof": 5.0,
                 "cytof_analysis": 2.0,
                 "olink": 8.0,
@@ -587,6 +591,8 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
                 "total_participants": 2,
                 "total_samples": 3,
                 "clinical_participants": 7.0,
+                "atacseq": 13.0,
+                "atacseq_analysis": 12.0,
                 "rna": 2.0,
                 "nanostring": 3.0,
                 "h&e": 5.0,


### PR DESCRIPTION
## What

Add subquery for counting ATACseq analysis to TrialMetadata.get_summaries() for Data Overview dashboard

## Why

[CIDC-1069](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1069)

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
