### PR TITLE
CIDC-1135 fix issue with setting offset in CSMS get_with_paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.40` - 12 Nov 2021
+
+- `fixed` bug in iterating offset in csms.auth.get_wget_with_paging
+
 ## Version `0.25.39` - 12 Nov 2021
 
 - `fixed` CSMS bug from chaining `detect_manifest_changes` and `insert_manifest_...`

--- a/cidc_api/csms/auth.py
+++ b/cidc_api/csms/auth.py
@@ -69,7 +69,7 @@ def get_with_paging(
         url should be fully valid or begin with `/` to be prefixed with CSMS_BASE_URL
     limit: int = None
         the number of records to return on each page
-        default: 5000 for samples, 50 for manifests
+        default: 5000 for samples, 50 for manifests, 1 otherwise
     offset: int = 0
         which page to return, 0-indexed
         increments as needed to continue returning
@@ -85,13 +85,16 @@ def get_with_paging(
             limit = 5000
         elif "manifests" in url:
             limit = 50
+        else:
+            limit = 1
+
     kwargs.update(dict(limit=limit, offset=offset))
 
     res = get_with_authorization(url, params=kwargs)
     while res.status_code < 300 and len(res.json().get("data", [])) > 0:
         # if there's not an error and we're still returning
         yield from res.json()["data"]
-        offset += 1  # get the next page
+        kwargs["offset"] += 1  # get the next page
         res = get_with_authorization(url, params=kwargs)
     else:
         res.raise_for_status()

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.39",
+    version="0.25.40",
     zip_safe=False,
 )

--- a/tests/models/templates/test_csms_api.py
+++ b/tests/models/templates/test_csms_api.py
@@ -150,8 +150,8 @@ def test_change_manifest_id_error(cidc_api, clean_db, monkeypatch):
 
             # make sure that you can then insert this manifest afterwards
             if n == 0:
-                insert_manifest_from_json(new_manifest)
-                insert_manifest_into_blob(new_manifest)
+                insert_manifest_from_json(new_manifest, uploader_email="test@email.com")
+                insert_manifest_into_blob(new_manifest, uploader_email="test@email.com")
 
 
 def test_change_cimac_id_error(cidc_api, clean_db, monkeypatch):


### PR DESCRIPTION
## What

fix issue with pointing to `offset` instead of `kwargs['offset']` in `csms.auth.get_with_paging()`
add test to prevent reversion

## Why

In testing for [CIDC-1135](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1135), logging found that was returning the same manifest repeatedly
[eg logs](https://cloudlogging.app.goo.gl/MV1wskQjzzKkwKSs8)\

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
