### PR TITLE
CIDC-1135 handling no shipment assay_type in dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## this
+
+- `added` handling in shipments dashboard for no shipment assay_type
+
 ## Version `0.25.42` - 15 Nov 2021
 
 - `fixed` correctly pass session in more places

--- a/cidc_api/dashboards/shipments.py
+++ b/cidc_api/dashboards/shipments.py
@@ -41,7 +41,7 @@ def get_manifest_samples(trial_id: str, manifest_id: str) -> Optional[pd.DataFra
     samples_df = pd.json_normalize(
         metadata_patch["participants"], "samples", meta=["cohort_name"]
     )
-    samples_df["assay_type"] = metadata_patch["shipments"][0]["assay_type"]
+    samples_df["assay_type"] = metadata_patch["shipments"][0].get("assay_type", "")
     samples_df["cimac_participant_id"] = samples_df.cimac_id.apply(lambda x: x[0:7])
     samples_df["manifest_id"] = manifest_id
     samples_df["cidc_received"] = upload_record._created

--- a/tests/dashboards/test_shipments.py
+++ b/tests/dashboards/test_shipments.py
@@ -50,12 +50,21 @@ def setup_data(cidc_api, clean_db):
         "shipping_condition": "Frozen_Dry_Ice",
         "quality_of_shipment": "Specimen shipment received in good condition",
     }
+    shipment2 = {
+        "courier": "FEDEX",
+        "manifest_id": "test_trial-H&E",
+        "account_number": "X",
+        "receiving_party": "MSSM_Rahman",
+        "shipping_condition": "Ambient",
+        "quality_of_shipment": "Specimen shipment received in good condition",
+    }
     metadata = {
         "protocol_identifier": trial_id,
         "shipments": [
             # we get duplicate shipment uploads sometimes
             shipment,
             shipment,
+            shipment2,
         ],
         "participants": [
             {

--- a/tests/dashboards/test_shipments.py
+++ b/tests/dashboards/test_shipments.py
@@ -210,8 +210,9 @@ def test_get_trial_shipments(cidc_api, clean_db):
 
     with cidc_api.app_context():
         shipments = get_trial_shipments(trial_id)
-        assert len(shipments) == 1
-        shipment = shipments[0]
-        assert shipment["cidc_received"] == upload_job._created
-        assert shipment["participant_count"] == num_participants
-        assert shipment["sample_count"] == sum(num_samples)
+        assert len(shipments) == 2
+
+        for shipment in shipments:
+            assert shipment["cidc_received"] == upload_job._created
+            assert shipment["participant_count"] == num_participants
+            assert shipment["sample_count"] == sum(num_samples)

--- a/tests/dashboards/test_shipments.py
+++ b/tests/dashboards/test_shipments.py
@@ -150,9 +150,10 @@ def setup_data(cidc_api, clean_db):
 
         clean_db.refresh(user)
         clean_db.refresh(upload_job)
+        clean_db.refresh(upload_job2)
         clean_db.refresh(trial)
 
-    return user, upload_job, trial
+    return user, (upload_job, upload_job2), trial
 
 
 def test_shipments_dashboard(cidc_api, clean_db, monkeypatch, dash_duo: DashComposite):
@@ -206,13 +207,13 @@ def test_get_manifest_samples(cidc_api, clean_db):
 
 def test_get_trial_shipments(cidc_api, clean_db):
     """Test the helper function used for getting a list of shipments for a given trial."""
-    _, upload_job, _ = setup_data(cidc_api, clean_db)
+    _, upload_jobs, _ = setup_data(cidc_api, clean_db)
 
     with cidc_api.app_context():
         shipments = get_trial_shipments(trial_id)
         assert len(shipments) == 2
 
         for shipment in shipments:
-            assert shipment["cidc_received"] == upload_job._created
+            assert shipment["cidc_received"] in [u._created for u in upload_jobs]
             assert shipment["participant_count"] == num_participants
             assert shipment["sample_count"] == sum(num_samples)

--- a/tests/dashboards/test_shipments.py
+++ b/tests/dashboards/test_shipments.py
@@ -93,22 +93,51 @@ def setup_data(cidc_api, clean_db):
     shipment2 = {
         "courier": "FEDEX",
         "manifest_id": "test_trial-H&E",
+        "account_number": "X",
+        "receiving_party": "MSSM_Rahman",
+        "shipping_condition": "Ambient",
+        "quality_of_shipment": "Specimen shipment received in good condition",
+    }
+    patch2 = {
+        "protocol_identifier": trial_id,
         "shipments": [shipment2,],
         "participants": [
+            {
+                "cimac_participant_id": f"CTTTP2{p}",
                 "participant_id": "x",
                 "cohort_name": "",
                 "samples": [
+                    {
+                        "cimac_id": f"CTTTPP{p}S2.0{s}",
+                        "sample_location": "",
+                        "type_of_primary_container": "Other",
                         "type_of_sample": "Other",
                         "collection_event_name": "",
+                        "parent_sample_id": "",
+                    }
+                    for s in range(num_samples[p])
+                ],
             }
             for p in range(num_participants)
+        ],
+        "allowed_cohort_names": [""],
+        "allowed_collection_event_names": [""],
+    }
+    upload_job2 = UploadJobs(
+        uploader_email=user.email,
+        trial_id=trial_id,
         upload_type="pbmc",
         gcs_xlsx_uri="",
         metadata_patch=patch2,
+        multifile=False,
     )
     upload_job2._set_status_no_validation(UploadJobStatus.MERGE_COMPLETED.value)
+
+    metadata = {
         "protocol_identifier": trial_id,
         "shipments": patch1["shipments"] + patch2["shipments"],
+        "participants": patch1["participants"] + patch2["participants"],
+        "allowed_cohort_names": [""],
         "allowed_collection_event_names": [""],
     }
     trial = TrialMetadata(trial_id=trial_id, metadata_json=metadata)
@@ -126,7 +155,6 @@ def setup_data(cidc_api, clean_db):
     return user, upload_job, trial
 
 
-@pytest.mark.skip()
 def test_shipments_dashboard(cidc_api, clean_db, monkeypatch, dash_duo: DashComposite):
     """
     Check that the shipments dashboard behaves as expected.


### PR DESCRIPTION
## What

Shipments added from CSMS don't have `assay_type` defined, which leads to a `KeyError` in `dashboards/shipments.py::get_manifest_samples`. Return `""` if not defined.

## Why

[logs](https://console.cloud.google.com/logs/query;query=%0AinsertId%3D%226192be31000d3b57519b332f%22)

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
