### PR TITLE
CIDC-1184 add capitalization conversion for CSMS value 'pbmc'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## this
+## Version `0.25.43` - this
 
+- `added` conversion for CSMS value 'pbmc' for processed sample type
 - `added` handling in shipments dashboard for no shipment assay_type
 
 ## Version `0.25.42` - 15 Nov 2021

--- a/cidc_api/models/templates/csms_api.py
+++ b/cidc_api/models/templates/csms_api.py
@@ -7,7 +7,6 @@ __all__ = [
 ]
 
 import os
-from re import L
 
 os.environ["TZ"] = "UTC"
 from collections import defaultdict, OrderedDict
@@ -242,6 +241,7 @@ def _convert_samples(
             "plasma": "Plasma",
             "normal_tissue_dna": "Tissue Scroll",
             "h_and_e": "H&E-Stained Fixed Tissue Slide Specimen",
+            "pbmc": "PBMC",
         }
         if sample["processed_sample_type"] in processed_sample_type_map:
             sample["processed_sample_type"] = processed_sample_type_map[

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.42",
+    version="0.25.43",
     zip_safe=False,
 )


### PR DESCRIPTION
## What

Add capitalization conversion for CSMS value 'pbmc' for `samples.processed_sample_type`

## Why

[This testing example](https://console.cloud.google.com/logs/query;query=resource.labels.function_name%3D%22update_cidc_from_csms%22%0Alabels.execution_id%3D%22m1umfjcjeppp%22;timeRange=PT3H;cursorTimestamp=2021-11-19T21:52:49.134Z?project=cidc-dfci-staging) raised an error trying to insert `pbmc` into `samples.processed_sample_type` as the correct value is `PBMC`, which is already used in the existing imports from CIDC blobs.

## How

Add a new conversion to [the existing mapping](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/9d7d73c85e00182f5de659f41420b9b9cc3982ca/cidc_api/models/templates/csms_api.py#L238-L245)

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
