### PR TITLE
CIDC-1135 Implement explicit dry_run option in templates/CSMS API insert methods 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## Version `0.25.43` - this
+## Version `0.25.44` - 22 Nov 2021
+
+- `added` dry_run option for both CSMS insert functions
+
+## Version `0.25.43` - 22 Nov 2021
 
 - `added` conversion for CSMS value 'pbmc' for processed sample type
 - `added` handling in shipments dashboard for no shipment assay_type

--- a/cidc_api/models/templates/csms_api.py
+++ b/cidc_api/models/templates/csms_api.py
@@ -296,10 +296,15 @@ def _convert_samples(
 
 @with_default_session
 def insert_manifest_into_blob(
-    manifest: Dict[str, Any], uploader_email: str, *, session: Session
+    manifest: Dict[str, Any],
+    uploader_email: str,
+    *,
+    dry_run: bool = False,
+    session: Session,
 ) -> None:
     """
     Given a CSMS-style manifest, add it into the JSON metadata blob
+    If `dry_run`, calls `session.rollback` instead of `session.commit`
     
     Exceptions Raised
     -----------------
@@ -397,7 +402,7 @@ def insert_manifest_into_blob(
         raise Exception({"prism errors": [str(e) for e in errs]})
 
     # save it
-    trial_md.update(changes={"metadata_json": merged}, session=session)
+    trial_md.update(changes={"metadata_json": merged}, commit=False, session=session)
 
     # create pseudo-UploadJobs
     UploadJobs(
@@ -407,15 +412,26 @@ def insert_manifest_into_blob(
         metadata_patch=patch,
         upload_type=_get_upload_type(samples),
         uploader_email=uploader_email,
-    ).insert(session=session)
+    ).insert(commit=False, session=session)
+
+    if dry_run:
+        session.flush()
+        session.rollback()
+    else:
+        session.commit()
 
 
 @with_default_session
 def insert_manifest_from_json(
-    manifest: Dict[str, Any], uploader_email: str, *, session: Session
+    manifest: Dict[str, Any],
+    uploader_email: str,
+    *,
+    dry_run: bool = False,
+    session: Session,
 ) -> None:
     """
     Given a CSMS-style manifest, validate and add it into the relational tables.
+    If `dry_run`, calls `session.rollback` instead of `session.commit`
     
     Exceptions Raised
     -----------------
@@ -563,7 +579,7 @@ def insert_manifest_from_json(
 
     # add and validate the data
     # the existence of the correct cohort names are checked here
-    errs = insert_record_batch(ordered_records, session=session)
+    errs = insert_record_batch(ordered_records, dry_run=dry_run, session=session)
     if len(errs):
         raise Exception("Multiple errors: [" + "\n".join(str(e) for e in errs) + "]")
 

--- a/cidc_api/models/templates/utils.py
+++ b/cidc_api/models/templates/utils.py
@@ -225,11 +225,25 @@ def insert_record_batch(
     if len(errors):
         session.rollback()
     elif hold_commit:
-        session.flush()
+        try:
+            session.flush()
+        except Exception as e:
+            errors.append(_handle_postgres_error(e, model))
+            session.rollback()
+
     elif dry_run:
+        try:
+            session.flush()
+        except Exception as e:
+            errors.append(_handle_postgres_error(e, model))
         session.rollback()
+
     else:
-        session.commit()
+        try:
+            session.commit()
+        except Exception as e:
+            errors.append(_handle_postgres_error(e, model))
+            session.rollback()
 
     return errors
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.43",
+    version="0.25.44",
     zip_safe=False,
 )

--- a/tests/models/templates/test_manifest_templates.py
+++ b/tests/models/templates/test_manifest_templates.py
@@ -90,7 +90,9 @@ def assert_pbmc_worked(cidc_api, clean_db):
         assert shipment.json_data["ship_to"] == "ship to"
 
         assert len(participants) == 2
-        for i, partic in enumerate(participants):
+        for i, partic in enumerate(
+            sorted(participants, key=lambda p: p.cimac_participant_id[-1])
+        ):
             assert partic.trial_id == "test_trial"
             assert partic.cimac_participant_id == f"CTTTP0{i+1}"
             assert partic.trial_participant_id == f"TTTP0{i+1}"
@@ -113,7 +115,7 @@ def assert_pbmc_worked(cidc_api, clean_db):
                 assert partic.json_data["ethnicity"] == "Unknown"
 
         assert len(samples) == 6
-        for i, sample in enumerate(samples):
+        for i, sample in enumerate(sorted(samples, key=lambda s: s.cimac_id[-6:-3])):
             partic = participants[i // 3]
 
             assert sample.trial_id == "test_trial"


### PR DESCRIPTION
## What

Implement dry_run kwarg for better error checking when not actually inserting.

## Why

Currently, dry_run of CSMS sync in cloud functions doesn't actually check any of the db values, so mainly errors caught by [models/templates/csms_api.py::_initial_manifest_validation](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/csms-dry_run/cidc_api/models/templates/csms_api.py#L748) were being checked in [models/templates/csms_api.py::detect_manifest_changes](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/csms-dry_run/cidc_api/models/templates/csms_api.py#L954).  
This allows for an explicit check and rollback call from the cloud function to both `insert_manifest_from_json` and `insert_manifest_into_blob`.

## How

- In `insert_manifest_into_blob`, pass `commit=False` to both the trial_metadata update or pseudo-upload insert -- only `commit` if not `dry_run`, otherwise `flush` and `rollback` 
- In `insert_manifest_from_json`, pass `dry_run` directly to existing kwarg in `insert_record_batch`. Also add explicit call to `flush` before `rollbacks` and improve error catching to said `models/templates/util.py` function.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
