### PR TITLE
CIDC-1187 add logging around failing ACL calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## Version `0.25.47` - this
+## Version `0.25.48` - 08 Dec 2021
+
+- `add` error logging in Permission.insert
+
+## Version `0.25.47` - 08 Dec 2021
 
 - `remove` all gcloud client logic associated with download logic ie conditional IAM permissions
 - `add` ACL gcloud client logic for downloads instead
 - `remove` all lister permission as no longer needed with ACL instead of IAM
+- `add` admin endpoint to call already existing function to grant all download permissions
 
 ## Version `0.25.46` - 30 Nov 2021
 

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -596,6 +596,8 @@ class Permissions(CommonColumns):
                 perm.insert(session=session)
             # Delete the just-created permissions record
             super().delete(session=session)
+
+            logger.warning(str(e))
             raise IAMException("IAM grant failed.") from e
 
     @with_default_session

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.47",
+    version="0.25.48",
     zip_safe=False,
 )


### PR DESCRIPTION
## What

add logging around failing ACL calls

## Why

While testing for test [CIDC-1187](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1187), trying to add permissions errors [in Permissions.insert](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/models/models.py#L599) after hitting [the logging grant_download_access](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/7504926685dcd00b0c20b41911ec8aba7f8b98b0/cidc_api/shared/gcloud_client.py#L214) but before [the equivalent in revoke_download_access](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/7504926685dcd00b0c20b41911ec8aba7f8b98b0/cidc_api/shared/gcloud_client.py#L234) which frames the new `client.list_blobs` and `acl.grant_reader` calls, so [here's a PR for better logging](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/7504926685dcd00b0c20b41911ec8aba7f8b98b0/cidc_api/shared/gcloud_client.py#L234)

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - README has been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
