### PR TITLE
CIDC-1187 1198 add explicit ACL save calls, reintroduce lister permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.51` - 15 Dec 2021
+
+- `added` calls to ACL save, and smoketests
+- `added` back calls for adding/removing lister permissions, and smoketests
+
 ## Version `0.25.50` - 14 Dec 2021
 
 - `fixed` ACL syntax again; see https://googleapis.dev/python/storage/latest/acl.html#google.cloud.storage.acl.ACL

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.50",
+    version="0.25.51",
     zip_safe=False,
 )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,10 +34,14 @@ def mock_gcloud_client(monkeypatch) -> MagicMock:
     gcloud_client = MagicMock()
     gcloud_client.revoke_download_access = MagicMock()
     gcloud_client.grant_download_access = MagicMock()
+    gcloud_client.revoke_lister_access = MagicMock()
+    gcloud_client.grant_lister_access = MagicMock()
 
     def reset_mocks():
         gcloud_client.grant_download_access.reset_mock()
         gcloud_client.revoke_download_access.reset_mock()
+        gcloud_client.grant_lister_access.reset_mock()
+        gcloud_client.revoke_lister_access.reset_mock()
 
     gcloud_client.reset_mocks = reset_mocks
 
@@ -48,6 +52,13 @@ def mock_gcloud_client(monkeypatch) -> MagicMock:
     monkeypatch.setattr(
         "cidc_api.models.models.revoke_download_access",
         gcloud_client.revoke_download_access,
+    )
+    monkeypatch.setattr(
+        "cidc_api.models.models.grant_lister_access", gcloud_client.grant_lister_access,
+    )
+    monkeypatch.setattr(
+        "cidc_api.models.models.revoke_lister_access",
+        gcloud_client.revoke_lister_access,
     )
 
     return gcloud_client


### PR DESCRIPTION
## What

- `added` calls to ACL save
- `added` back calls for adding/removing lister permissions

## Why

![image](https://user-images.githubusercontent.com/7273167/146248072-29bddc0f-20cc-4538-b6e6-7b0e0967695f.png)

## How

Grep'd for all `acl` calls in both cidc_api and tests.
Copy-pasted old code for lister permissions with minimal updates.

## Remarks

Add notes on possible known quirks/drawbacks of this solution.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
