### PR TITLE
Fix CyTOF filter group for analysis-ready

### DIFF
--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -716,17 +716,17 @@ details_dict = {
         "comma-separated two-column table with cell counts for each profiled subset of assigned cell types",
         "A plain-text, comma-separated table with a numbered index column, the 'CellSubset' as the broad compartment of the called cell types, and 'N', the number of cells within that profiled subset seen in the sample.",
     ),
-    f"/cytof_analysis/combined_cell_counts_assignment.csv": FileDetails(
+    "csv|cell counts assignment": FileDetails(
         "analysis",
         "comma-separated two-column table with cell counts for each assigned cell type",
         "A plain-text, comma-separated table with a numbered index column, the 'CellSubset' as the called cell type, and 'N', the number of cells of that type seen in the sample.",
     ),
-    f"/cytof_analysis/combined_cell_counts_compartment.csv": FileDetails(
+    f"csv|cell counts compartment": FileDetails(
         "analysis",
         "comma-separated two-column table with cell counts for each broad compartment assigned",
         "A plain-text, comma-separated table with a numbered index column, the 'CellSubset' as the broad compartment of the called cell types, and 'N', the number of cells within that compartment seen in the sample.",
     ),
-    f"/cytof_analysis/combined_cell_counts_profiling.csv": FileDetails(
+    f"csv|cell counts profiling": FileDetails(
         "analysis",
         "comma-separated two-column table with cell counts for each profiled subset of all assigned cell types",
         "A plain-text, comma-separated table with a numbered index column, the 'CellSubset' as the profiled subset of the assigned cell types, and 'N', the number of cells within that profiled subset seen in the sample.",

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -389,9 +389,9 @@ analysis_ready_facets = {
     "Olink": FacetConfig(["npx|analysis_ready|csv"]),
     "CyTOF": FacetConfig(
         [
-            "/cytof_analysis/combined_cell_counts_compartment.csv",
-            "/cytof_analysis/combined_cell_counts_assignment.csv",
-            "/cytof_analysis/combined_cell_counts_profiling.csv",
+            "csv|cell counts assignment",
+            "csv|cell counts compartment",
+            "csv|cell counts profiling",
         ],
         "Summary cell counts, combined across all samples in the trial",
     ),

--- a/tests/resources/test_trial_metadata.py
+++ b/tests/resources/test_trial_metadata.py
@@ -190,7 +190,6 @@ def test_list_trials(cidc_api, clean_db, monkeypatch):
     assert res.json["_items"][0]
     [trial_json_1, trial_json_2] = res.json["_items"]
     assert set(trial_json_1["file_bundle"]["CyTOF"]["source"]) == set([0, 1])
-    assert trial_json_1["file_bundle"]["CyTOF"]["analysis"] == [2]
     assert trial_json_1["file_bundle"]["WES"]["source"] == [3]
     assert trial_json_1["num_samples"] == 1
     assert trial_json_1["num_participants"] == 1


### PR DESCRIPTION
## What

Revert changes in #640 and replace file path with correct filter group

## Why

Describe what motivated this Pull Request and why this was necessary. Link to the relevant JIRA Issue. Ex. Closes CIDC-1086

## How

Describe details of how you implemented the solution, outlining the major steps involved in adding this new feature or fixing this bug. Provide code-snippets if possible, showing example usage.

## Remarks

Add notes on possible known quirks/drawbacks of this solution.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
