### PR TITLE
CIDC-1187 1198 move grant all trigger to CFn

### DIFF
--- a/.env
+++ b/.env
@@ -37,6 +37,7 @@ GOOGLE_UPLOAD_TOPIC='uploads'
 GOOGLE_EMAILS_TOPIC='emails'
 GOOGLE_PATIENT_SAMPLE_TOPIC='patient_sample_update'
 GOOGLE_ARTIFACT_UPLOAD_TOPIC='artifact_upload'
+GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC='grant_download_perms'
 
 CSMS_CLIENT_ID='csms-client'
 CSMS_CLIENT_SECRET='csms-secret'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.25.54` - 22 Dec 2021
+
+- `changed` admin grant all download permissions to run through cloud function
+
 ## Version `0.25.53` - 16 Dec 2021
 
 - `removed` all IAM conditions on data bucket

--- a/app.prod.yaml
+++ b/app.prod.yaml
@@ -39,5 +39,6 @@ env_variables:
   GOOGLE_EMAILS_TOPIC: "emails"
   GOOGLE_PATIENT_SAMPLE_TOPIC: "patient_sample_update"
   GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
+  GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC: "grant_download_perms"
   GOOGLE_UPLOAD_ROLE: "projects/cidc-dfci/roles/objectUploader"
   GOOGLE_LISTER_ROLE: "projects/cidc-dfci/roles/CustomRoleLister"

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -31,5 +31,6 @@ env_variables:
   GOOGLE_EMAILS_TOPIC: "emails"
   GOOGLE_PATIENT_SAMPLE_TOPIC: "patient_sample_update"
   GOOGLE_ARTIFACT_UPLOAD_TOPIC: "artifact_upload"
+  GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC: "grant_download_perms"
   GOOGLE_UPLOAD_ROLE: "projects/cidc-dfci-staging/roles/objectUploader"
   GOOGLE_LISTER_ROLE: "projects/cidc-dfci-staging/roles/CustomRoleLister"

--- a/cidc_api/config/settings.py
+++ b/cidc_api/config/settings.py
@@ -92,6 +92,9 @@ GOOGLE_DOWNLOAD_ROLE = "roles/storage.objectViewer"  # same across environments
 GOOGLE_PATIENT_SAMPLE_TOPIC = environ["GOOGLE_PATIENT_SAMPLE_TOPIC"]
 GOOGLE_EMAILS_TOPIC = environ["GOOGLE_EMAILS_TOPIC"]
 GOOGLE_ARTIFACT_UPLOAD_TOPIC = environ["GOOGLE_ARTIFACT_UPLOAD_TOPIC"]
+GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC = environ[
+    "GOOGLE_GRANT_DOWNLOAD_PERMISSIONS_TOPIC"
+]
 
 ### File paths ###
 this_directory = path.dirname(path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
-    version="0.25.53",
+    version="0.25.54",
     zip_safe=False,
 )


### PR DESCRIPTION
## What

- Change admin endpoint to grant all download permissions to run through cloud function
- Also tweak grant/revoke all functions to make fewer get/set ACL policy calls 

## Why

Currently, running over the 10mins that API times out at -- cloud functions can have a much longer time out that's under our control.

## How

Just publish (an empty dict) to `grant_download_perms` channel

## Remarks

May still be too slow, next idea is to include trial / upload matching to run in smaller batches.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [x] Package version - Manually bumped the API package version in [setup.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/setup.py#L21)
