### PR TITLE
CIDC-1218 test on python 3.8 and 9 instead of 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -27,10 +30,10 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## What

Test on Python 3.8 and 3.9 instead of 3.7

## Why

Modernization

## How

Copied `strategy` from `cidc-cli` CI