### PR TITLE
CIDC-1243 add hsts to response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 4 May 2022
+
+- `added` `security` HSTS (headers) to prod and staging
+  - [instructs browser to prefer `https`](https://cloud.google.com/appengine/docs/flexible/python/how-requests-are-handled#forcing_https_connections)
+
 ## Version `0.26.10` - 2 May 2022
 
 - `changed` black, flask, werkzeug, jinja2, schemas version bumps

--- a/app.prod.yaml
+++ b/app.prod.yaml
@@ -21,6 +21,8 @@ handlers:
     script: auto
     secure: always
     redirect_http_response_code: 301
+    http_headers:
+      Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 env_variables:
   ENV: "prod"

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -13,6 +13,8 @@ handlers:
     script: auto
     secure: always
     redirect_http_response_code: 301
+    http_headers:
+      Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 env_variables:
   ENV: "staging"


### PR DESCRIPTION
## What

Add HSTS ie [RFC 6797](https://datatracker.ietf.org/doc/rfc6797/) to API responses on both production and staging.
Briefly, Http Strict Transport Security [instruct\[s\] the browser to prefer `https` over `http`](https://cloud.google.com/appengine/docs/flexible/python/how-requests-are-handled#forcing_https_connections),

> enabling web sites to declare themselves accessible only via secure connections and/or for users to be able to direct their user agent(s) to interact with given sites only over secure connections.

\- *[RFC 6797](https://datatracker.ietf.org/doc/rfc6797/) Abstract*

## Why

[CIDC-1243](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1243)
> CVSS: 5.8
Risk: Medium
Hosts: portal.cimac-network.org, stagingportal.cimac-network.org & api.cimac-network.org​

## How

Per [Google's recommendation to force https via STS](https://cloud.google.com/appengine/docs/flexible/python/how-requests-are-handled#forcing_https_connections), [added to `http_headers` of the `handlers` for `url: ./*`](https://cloud.google.com/appengine/docs/standard/python/config/appref#handlers_http_headers) in `app.[ENV].yaml`.

## Remarks

No way to test within current structure to my knowledge. Have to wait for next scan to see if remedied.
Doesn't require version bump as not within python package at all, just a directive to the GAE.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
