### PR TITLE
CIDC-1243 replace config http_header with flask_talisman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## 4 May 2022
+## 5 May 2022
 
 - `added` `security` HSTS (headers) to prod and staging
   - [instructs browser to prefer `https`](https://cloud.google.com/appengine/docs/flexible/python/how-requests-are-handled#forcing_https_connections)
+- added [`wait_for_element_by_id` call](https://stackoverflow.com/questions/27112731/selenium-common-exceptions-nosuchelementexception-message-unable-to-locate-ele) tester
 
 ## Version `0.26.10` - 2 May 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ This Changelog tracks changes to this project. The notes below include a summary
 
 - `added` `security` HSTS (headers) to prod and staging
   - [instructs browser to prefer `https`](https://cloud.google.com/appengine/docs/flexible/python/how-requests-are-handled#forcing_https_connections)
-- added [`wait_for_element_by_id` call](https://stackoverflow.com/questions/27112731/selenium-common-exceptions-nosuchelementexception-message-unable-to-locate-ele) tester
+- `added` [wait_for_element_by_id call](https://stackoverflow.com/questions/27112731/selenium-common-exceptions-nosuchelementexception-message-unable-to-locate-ele) tester
+- `added` `security` Content Security Policy whitelist [for bootstrap, jquery](https://stackoverflow.com/questions/54730178/flask-talisman-breaks-flask-bootstrap)
 
 ## Version `0.26.10` - 2 May 2022
 

--- a/app.prod.yaml
+++ b/app.prod.yaml
@@ -21,8 +21,6 @@ handlers:
     script: auto
     secure: always
     redirect_http_response_code: 301
-    http_headers:
-      Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 env_variables:
   ENV: "prod"

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -13,8 +13,6 @@ handlers:
     script: auto
     secure: always
     redirect_http_response_code: 301
-    http_headers:
-      Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 env_variables:
   ENV: "staging"

--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -24,7 +24,7 @@ Talisman(
     app,
     # disable https if app is run in testing mode
     # flask's test_client doesn't use https for some reason
-    force_https = not app.config['TESTING'],
+    force_https=not app.config["TESTING"],
 )
 
 # Set up the database and run the migrations

--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -2,6 +2,7 @@ import traceback
 
 from flask import Flask, jsonify
 from flask_cors import CORS
+from flask_talisman import Talisman
 from werkzeug.exceptions import HTTPException
 from marshmallow.exceptions import ValidationError
 
@@ -17,8 +18,14 @@ logger = get_logger(__name__)
 app = Flask(__name__, static_folder=None)
 app.config.update(SETTINGS)
 
-# Enable CORS
+# Enable CORS and HSTS
 CORS(app, resources={r"*": {"origins": app.config["ALLOWED_CLIENT_URL"]}})
+Talisman(
+    app,
+    # disable https if app is run in testing mode
+    # flask's test_client doesn't use https for some reason
+    force_https = not app.config['TESTING'],
+)
 
 # Set up the database and run the migrations
 init_db(app)

--- a/cidc_api/app.py
+++ b/cidc_api/app.py
@@ -20,11 +20,20 @@ app.config.update(SETTINGS)
 
 # Enable CORS and HSTS
 CORS(app, resources={r"*": {"origins": app.config["ALLOWED_CLIENT_URL"]}})
+csp = {
+    "default-src": [
+        "'self'",
+        "stackpath.bootstrapcdn.com",
+        "code.jquery.com",
+        "cdn.jsdelivr.net",
+    ]
+}
 Talisman(
     app,
     # disable https if app is run in testing mode
     # flask's test_client doesn't use https for some reason
     force_https=not app.config["TESTING"],
+    content_security_policy=csp,
 )
 
 # Set up the database and run the migrations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask-cors==3.0.9
+flask_talisman==0.7.0
 six==1.13.0
 python-jose==3.0.1
 psycopg2-binary==2.8.3

--- a/tests/dashboards/test_shipments.py
+++ b/tests/dashboards/test_shipments.py
@@ -170,6 +170,7 @@ def test_shipments_dashboard(cidc_api, clean_db, monkeypatch, dash_duo: DashComp
 
         dash_duo.server(shipments_dashboard)
         dash_duo.wait_for_page(f"{dash_duo.server.url}/dashboards/upload_jobs/")
+        dash_duo.wait_for_element_by_id(f"#{TRIAL_DROPDOWN}")
 
         if CIDCRole(role) == CIDCRole.ADMIN:
             # open trial dropdown


### PR DESCRIPTION
## What

Change HSTS ie [RFC 6797](https://datatracker.ietf.org/doc/rfc6797/) implementation.
Briefly, Http Strict Transport Security [instruct\[s\] the browser to prefer `https` over `http`](https://cloud.google.com/appengine/docs/flexible/python/how-requests-are-handled#forcing_https_connections),

> enabling web sites to declare themselves accessible only via secure connections and/or for users to be able to direct their user agent(s) to interact with given sites only over secure connections.

\- *[RFC 6797](https://datatracker.ietf.org/doc/rfc6797/) Abstract*

## Why

[`http_headers` doesn't work for dynamic handlers](https://github.com/CIMAC-CIDC/cidc-api-gae/runs/6295250714?check_suite_focus=true#step:5:15)

## How

From https://github.com/GoogleCloudPlatform/flask-talisman
- require `flask_talisman` for app, but not modules
- pass `app: Flask` to `flask_talisman.Talisman`
- pass `force_https=False` during (and only for) testing; see Remarks

## Remarks

- No way to test within current structure to my knowledge. Have to wait for next scan to see if remedied.
- Doesn't require version bump as not within python package at all, just a directive and added requirement to the GAE.
- Need to have conditional to NOT require `https` when `TESTING` to [prevent `Flask`'s `test_client` from throwing `201`s without `follow_redirects: True`
- Peg to latest version of `flask_talisman==0.7.0`, from 2019-05-28

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
