### PR TITLE
CIDC-1054 add explicit pypi long_description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `changed` order of user and url in single file download
 - `changed` WES counting to reflect new system
 - `added` new downloadable_files endpoint to return all facets grouped by assay
+- `added` README.md as pypi long_description
 
 ## 6 May 2022
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ from setuptools import setup
 with open("requirements.modules.txt") as f:
     requirements = f.read().splitlines()
 
+with open("README.md") as f:
+    long_description = f.read()
+
 from cidc_api import __version__
 
 setup(
@@ -22,6 +25,8 @@ setup(
         "cidc_api.models.templates",
     ],
     url="https://github.com/CIMAC-CIDC/cidc_api-gae",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     version=__version__,
     zip_safe=False,
 )


### PR DESCRIPTION
## What

Add explicit pypi long_description

## Why

PyPI deploy [is currently failing](https://github.com/CIMAC-CIDC/cidc-api-gae/runs/6514626075?check_suite_focus=true#step:5:11) on `long_description` despite not providing one

## How

Per [python's documentation](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata) provide the contents of `README.md` as `long_description` to `setup`  with `long_description_content_type` as `text/markdown`.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
