### PR TITLE
CIDC-966 allow 1GiB batch downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 13 Jun 2022
+
+- `changed` max download size from 100MB to 1GiB
+
 ## Version `0.26.14` - 9 Jun 2022
 
 - `changed` schemas bump for Microbiome support

--- a/cidc_api/resources/downloadable_files.py
+++ b/cidc_api/resources/downloadable_files.py
@@ -121,7 +121,7 @@ def _get_object_urls_or_404(ids: List[int]) -> List[str]:
     return urls
 
 
-MAX_BUNDLE_BYTES = int(1e8)  # 100MB
+MAX_BUNDLE_BYTES = int(2**30)  # 1GiB
 
 
 @downloadable_files_bp.route("/compressed_batch", methods=["POST"])
@@ -133,8 +133,8 @@ def create_compressed_batch(args):
     into a single file. Respond with a GCS signed URL for downloading the
     compressed file.
 
-    Currently, onl file batches with size <=100MB are supported. If the total file
-    size of the requested files is greater than 100MB, respond with HTTP status code
+    Currently, onl file batches with size <= 1GiB are supported. If the total file
+    size of the requested files is greater than 1GiB, respond with HTTP status code
     400 (Bad Request).
     """
     urls = _get_object_urls_or_404(args["file_ids"])

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -59,7 +59,7 @@ def setup_downloadable_files(cidc_api) -> Tuple[int, int]:
             object_url=f"{trial_id}/{object_url}",
             facet_group=facet_group,
             uploaded_timestamp=datetime.now(),
-            file_size_bytes=int(51 * 1e6),  # 51MB
+            file_size_bytes=int(0.6 * 2**30),  # 0.6GiB
         )
 
     wes_file = make_file(
@@ -358,7 +358,7 @@ def test_create_compressed_batch(cidc_api, clean_db, monkeypatch):
     mock_logger = MagicMock()
     monkeypatch.setattr("cidc_api.resources.downloadable_files.logger", mock_logger)
 
-    # User has one permission, s0 the endpoint should try to create
+    # User has one permission, so the endpoint should try to create
     # a compressed batch file with the single file the user has
     # access to in it.
     res = client.post(url, json=short_file_list)
@@ -379,6 +379,7 @@ def test_create_compressed_batch(cidc_api, clean_db, monkeypatch):
     make_admin(user_id, cidc_api)
 
     # Admin has access to both files, but together they are too large
+    # 2 files of 0.6GiB each is 1.2GiB > 1GiB
     res = client.post(url, json=short_file_list)
     assert res.status_code == 400
     assert "batch too large" in res.json["_error"]["message"]
@@ -386,6 +387,7 @@ def test_create_compressed_batch(cidc_api, clean_db, monkeypatch):
     blob.upload_from_filename.assert_not_called()
 
     # Decrease the size of one of the files and try again
+    # 0.6GiB + 1B < 1GiB
     with cidc_api.app_context():
         df = DownloadableFiles.find_by_id(file_id_1)
         df.file_size_bytes = 1


### PR DESCRIPTION
## What

Expand maximum batch download size from 100MB to 1GiB, about 10x larger.

## Why

- [CIDC-966](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-966) Consider support for direct download of larger batches (1-2GB)

## How

Change `MAX_BUNDLE_BYTES` in `cidc_api/resources/downloadable_files.py` to `2 ** 30` = 1 GiB

## Remarks

local testing shows compressing 1.1GiB (larger than currently proposed 1GiB) takes 37sec. API time-out is 60sec, so testing on staging should be done

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
