### PR TITLE
CIDC-964 zip compress batch downloads, not gztar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 13 Jun 2022
+
+- `changed` compression for downloaded batches from gztar to zip
+
 ## Version `0.26.14` - 9 Jun 2022
 
 - `changed` schemas bump for Microbiome support

--- a/cidc_api/resources/downloadable_files.py
+++ b/cidc_api/resources/downloadable_files.py
@@ -133,7 +133,7 @@ def create_compressed_batch(args):
     into a single file. Respond with a GCS signed URL for downloading the
     compressed file.
 
-    Currently, onl file batches with size <=100MB are supported. If the total file
+    Currently, only file batches with size <=100MB are supported. If the total file
     size of the requested files is greater than 100MB, respond with HTTP status code
     400 (Bad Request).
     """
@@ -167,7 +167,7 @@ def create_compressed_batch(args):
         # Create a compressed file from the contents of the temporary directory
         random_filename = str(uuid4())
         outpath = shutil.make_archive(
-            os.path.join(tmpdir, random_filename), "gztar", indir
+            os.path.join(tmpdir, random_filename), "zip", indir
         )
 
         # Upload the compressed file to the ephemeral bucket, where

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -341,7 +341,7 @@ def test_create_compressed_batch(cidc_api, clean_db, monkeypatch):
         )
         perm.insert()
 
-    # Mock GCS client and loger
+    # Mock GCS client and logger
     blob = MagicMock()
     bucket = MagicMock()
     bucket.blob.return_value = blob


### PR DESCRIPTION
## What

Change batch downloads to use ZIP compression instead of tar.gz

## Why

- [CIDC-964](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-964) Direct batch downloads should produce "zip" files, not "tar.gz"

## How

replace format arg in `shutil.make_archive` from `gztar` to `zip` per their documentation.

## Remarks

Per Jacob's solution in ticket description

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
