### PR TITLE
CIDC-966 lower max batch download size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 14 Jun 2022
+
+- `changed` max download size from 1GiB to 400MB
+  - with instance_class in app.yaml as F2, 512MB memory limit
+
 ## Version `0.26.15` - 13 Jun 2022
 
 - `added` requirements for \_etag, \_created, \_updated

--- a/cidc_api/resources/downloadable_files.py
+++ b/cidc_api/resources/downloadable_files.py
@@ -121,7 +121,7 @@ def _get_object_urls_or_404(ids: List[int]) -> List[str]:
     return urls
 
 
-MAX_BUNDLE_BYTES = int(2**30)  # 1GiB
+MAX_BUNDLE_BYTES = 4 * int(10**8)  # 400MB
 
 
 @downloadable_files_bp.route("/compressed_batch", methods=["POST"])

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -59,7 +59,7 @@ def setup_downloadable_files(cidc_api) -> Tuple[int, int]:
             object_url=f"{trial_id}/{object_url}",
             facet_group=facet_group,
             uploaded_timestamp=datetime.now(),
-            file_size_bytes=int(0.6 * 2**30),  # 0.6GiB
+            file_size_bytes=2.1 * int(10**8),  # 210MB
         )
 
     wes_file = make_file(
@@ -379,7 +379,7 @@ def test_create_compressed_batch(cidc_api, clean_db, monkeypatch):
     make_admin(user_id, cidc_api)
 
     # Admin has access to both files, but together they are too large
-    # 2 files of 0.6GiB each is 1.2GiB > 1GiB
+    # 2 files of 210MB each is 420MB > 400MB
     res = client.post(url, json=short_file_list)
     assert res.status_code == 400
     assert "batch too large" in res.json["_error"]["message"]
@@ -387,7 +387,7 @@ def test_create_compressed_batch(cidc_api, clean_db, monkeypatch):
     blob.upload_from_filename.assert_not_called()
 
     # Decrease the size of one of the files and try again
-    # 0.6GiB + 1B < 1GiB
+    # 210MB + 1B < 400MB
     with cidc_api.app_context():
         df = DownloadableFiles.find_by_id(file_id_1)
         df.file_size_bytes = 1


### PR DESCRIPTION
## What

Lowered the maximum size for batch downloads from 1GiB to 400MB

## Why

- With `instance_class` in `app.[ENV].yaml` as F2, there is a 512MB memory limit. See [GAE docs](https://cloud.google.com/appengine/docs/standard#instance_classes).
- Discovered in testing on staging.

## Remarks

- Requires more testing on staging to make sure that it can compress 400MB with a 512MB limit.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
