### PR TITLE
CIDC-966 lower max batch download size more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ This Changelog tracks changes to this project. The notes below include a summary
 
 ## 14 Jun 2022
 
-- `changed` max download size from 1GiB to 400MB
+- `changed` reverted max download size from 1GiB to 100MB
   - with instance_class in app.yaml as F2, 512MB memory limit
+  - testing on staging shows 100MB is likely functional limit for GAE-processed
 
 ## Version `0.26.15` - 13 Jun 2022
 

--- a/cidc_api/resources/downloadable_files.py
+++ b/cidc_api/resources/downloadable_files.py
@@ -121,7 +121,7 @@ def _get_object_urls_or_404(ids: List[int]) -> List[str]:
     return urls
 
 
-MAX_BUNDLE_BYTES = 4 * int(10**8)  # 400MB
+MAX_BUNDLE_BYTES = int(1e8)  # 100MB
 
 
 @downloadable_files_bp.route("/compressed_batch", methods=["POST"])

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -59,7 +59,7 @@ def setup_downloadable_files(cidc_api) -> Tuple[int, int]:
             object_url=f"{trial_id}/{object_url}",
             facet_group=facet_group,
             uploaded_timestamp=datetime.now(),
-            file_size_bytes=2.1 * int(10**8),  # 210MB
+            file_size_bytes=int(51 * 1e6),  # 51MB
         )
 
     wes_file = make_file(
@@ -379,7 +379,7 @@ def test_create_compressed_batch(cidc_api, clean_db, monkeypatch):
     make_admin(user_id, cidc_api)
 
     # Admin has access to both files, but together they are too large
-    # 2 files of 210MB each is 420MB > 400MB
+    # 2 files of 51MB each is 102MB > 100MB
     res = client.post(url, json=short_file_list)
     assert res.status_code == 400
     assert "batch too large" in res.json["_error"]["message"]
@@ -387,7 +387,7 @@ def test_create_compressed_batch(cidc_api, clean_db, monkeypatch):
     blob.upload_from_filename.assert_not_called()
 
     # Decrease the size of one of the files and try again
-    # 210MB + 1B < 400MB
+    # 51MB + 1B < 100MB
     with cidc_api.app_context():
         df = DownloadableFiles.find_by_id(file_id_1)
         df.file_size_bytes = 1


### PR DESCRIPTION
## What

Lowered the maximum size for batch downloads from 400MB back to the original 100MB

## Why

- With `instance_class` in `app.[ENV].yaml` as F2, there is a 512MB memory limit. See [GAE docs](https://cloud.google.com/appengine/docs/standard#instance_classes).
- Discovered in testing on staging that functional limit is below 200MB.

## Remarks

- As this is resetting to original value, asserting that this will work.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
