### PR TITLE
CIDC-896 add flask-cachecontrol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 30 Jun 2022
+
+- `added` flask-cachecontrol to prevent caching of /users/data_access_report
+
 ## Version `0.26.17` - 21 Jun 2022
 
 - `added` new wes bait set to relational db

--- a/cidc_api/resources/users.py
+++ b/cidc_api/resources/users.py
@@ -5,6 +5,7 @@ os.environ["TZ"] = "UTC"
 from datetime import datetime
 
 from flask import Blueprint, send_file
+from flask_cachecontrol import dont_cache
 from werkzeug.exceptions import BadRequest
 
 from ..shared.auth import get_current_user, requires_auth
@@ -135,6 +136,7 @@ def update_user(user: Users, user_updates: Users):
 
 @users_bp.route("/data_access_report", methods=["GET"])
 @requires_auth("users_data_access_report", [CIDCRole.ADMIN.value])
+@dont_cache()
 def get_data_access_report():
     """Generate the user data access report."""
     buffer = io.BytesIO()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask-cors==3.0.9
+flask-cachecontrol==0.3.0
 six==1.13.0
 python-jose==3.0.1
 psycopg2-binary==2.8.3


### PR DESCRIPTION
## What

Tell Google/browsers not to cache the data access report

## Why

- [CIDC-896](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-896)
- Updates to the admin user table should immediately be reflected in the xlsx report.

## How

- Google App Engine's [python docs on response caching](https://cloud.google.com/appengine/docs/standard/python3/how-requests-are-handled#response_caching) specifies that responses are cached for 10 mins by default
- They are not be cached by Google Frontend if a `Cache-control` response header is set to `no-store`
- [Mozilla's http refence docs for response directives](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#response_directives)
- [Flask-CacheControl](https://pypi.org/project/Flask-CacheControl/)'s [`dont_cache` decorator](https://github.com/twiebe/Flask-CacheControl/blob/main/src/flask_cachecontrol/decorate.py#L81) adds the `Cache-Control` directives `proxy-revalidate, no-cache, no-store, must-revalidate, max-age=0`

## Remarks

- did not perform local test

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
