### PR TITLE
CIDC-1421 Expand faceting to correctly label new hande images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 16 Aug 2022
+
+- `changed` edit H&E faceting to correctly label all new image uploads re allowing jpg files
+
 ## Version `0.26.27` - 15 Aug 2022
 
 - `changed` bump schemas for ctdna analysis nulls and hande jpeg files

--- a/cidc_api/models/files/details.py
+++ b/cidc_api/models/files/details.py
@@ -1027,6 +1027,11 @@ details_dict = {
         "stained image file that is the result of an H&E experiment",
         "An SVS image file stained with hematoxylin and eosin, generated from an H&E experiment.",
     ),
+    "/hande/image_file.": FileDetails(
+        "source",
+        "stained image file that is the result of an H&E experiment",
+        "An image file stained with hematoxylin and eosin, generated from an H&E experiment.",
+    ),
     # ELISA
     "/elisa/assay.xlsx": FileDetails(
         "source",

--- a/cidc_api/models/files/facets.py
+++ b/cidc_api/models/files/facets.py
@@ -401,7 +401,11 @@ assay_facets: Facets = {
         "Images": FacetConfig(["/ihc/ihc_image."]),
         "Combined Markers": FacetConfig(["csv|ihc marker combined"]),
     },
-    "H&E": {"Images": FacetConfig(["/hande/image_file.svs"], "Stained image file.")},
+    "H&E": {
+        "Images": FacetConfig(
+            ["/hande/image_file.svs", "/hande/image_file."], "Stained image file."
+        )
+    },
     "TCR": {
         "Source": FacetConfig(
             [


### PR DESCRIPTION
## What

Expand faceting to correctly label new hande images

## Why

newly ingested files are incorrectly facetted with new changes

## How

Describe details of how you implemented the solution, outlining the major steps involved in adding this new feature or fixing this bug. Provide code-snippets if possible, showing example usage.

## Remarks

Add notes on possible known quirks/drawbacks of this solution.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
