### PR TITLE
CIDC-1543 fix bug in wes_tumor_only_analysis dashboard counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 17 Nov 2022
+
+- `fixed` wes_tumor_only_analysis dashboard counting
+
 ## 14 Nov 2022
 
 - `removed` facets not used in the database or derived from current templates

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -1564,7 +1564,7 @@ class TrialMetadata(CommonColumns):
             select
                 trial_id,
                 'wes_tumor_only_analysis' as key,
-                run->>'cimac_id' as cimac_id
+                run>>#'{tumor,cimac_id}' as cimac_id
             from
                 trial_metadata,
                 jsonb_array_elements(metadata_json#>'{analysis,wes_tumor_only_analysis,runs}') run
@@ -1574,7 +1574,7 @@ class TrialMetadata(CommonColumns):
             select
                 trial_id,
                 'wes_tumor_only_analysis' as key,
-                run->>'cimac_id' as cimac_id
+                run#>>'{tumor,cimac_id}' as cimac_id
             from
                 trial_metadata,
                 jsonb_array_elements(metadata_json#>'{analysis,wes_tumor_only_analysis_old,runs}') run

--- a/cidc_api/models/models.py
+++ b/cidc_api/models/models.py
@@ -1564,7 +1564,7 @@ class TrialMetadata(CommonColumns):
             select
                 trial_id,
                 'wes_tumor_only_analysis' as key,
-                run>>#'{tumor,cimac_id}' as cimac_id
+                run#>>'{tumor,cimac_id}' as cimac_id
             from
                 trial_metadata,
                 jsonb_array_elements(metadata_json#>'{analysis,wes_tumor_only_analysis,runs}') run

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -552,12 +552,22 @@ def test_trial_metadata_get_summaries(clean_db, monkeypatch):
                 "excluded_samples": make_records(1, 2),
             },
             "wes_tumor_only_analysis": {
-                # wes_tumor_only_analysis = 2; 1 here, 1 below
-                "runs": make_records(0, 1, report={"report": "foo"}),
+                "runs": [
+                    # wes_tumor_only_analysis = 2; 1 here, 1 below
+                    {
+                        "tumor": {"cimac_id": "C000000T4"},
+                        "report": {"report": "foo"},
+                    },
+                ],
             },
             "wes_tumor_only_analysis_old": {
-                # wes_tumor_only_analysis = 2; 1 here, 1 above
-                "runs": make_records(1, 2, report={"report": "foo"}),
+                "runs": [
+                    # wes_tumor_only_analysis = 2; 1 here, 1 above
+                    {
+                        "tumor": {"cimac_id": "C000000T5"},
+                        "report": {"report": "foo"},
+                    },
+                ],
             },
         },
         "clinical_data": {


### PR DESCRIPTION
## What

fix bug in wes_tumor_only_analysis dashboard counting

## Why

counts were not functioning on portal

## How

fixed query, that was looking for cimac IDs in wrong location on blob

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
