### PR TITLE
CIDC-1562 handle spaces in filelist.tsv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 01 Dec 2022
+
+- `added` space handling to downloadable filelist.tsv url
+
 ## Version `0.27.24` - 30 Nov 2022
 
 - `removed` references to permission system in cloud functions for biofx

--- a/cidc_api/resources/downloadable_files.py
+++ b/cidc_api/resources/downloadable_files.py
@@ -199,7 +199,8 @@ def generate_filelist(args):
     tsv = b""
     for url in urls:
         flat_url = url.replace("/", "_")
-        full_gcs_uri = f"gs://{GOOGLE_ACL_DATA_BUCKET}/{url}"
+        flat_url = flat_url.replace(" ", "_")
+        full_gcs_uri = f'"gs://{GOOGLE_ACL_DATA_BUCKET}/{url}"'
         tsv += bytes(f"{full_gcs_uri}\t{flat_url}\n", "utf-8")
 
     buffer = BytesIO(tsv)

--- a/tests/resources/test_downloadable_files.py
+++ b/tests/resources/test_downloadable_files.py
@@ -66,7 +66,7 @@ def setup_downloadable_files(cidc_api) -> Tuple[int, int, int]:
         )
 
     wes_file = make_file(
-        trial_id_1, "wes/.../reads_123.bam", "wes_bam", "/wes/r1_L.fastq.gz"
+        trial_id_1, "wes/.../reads 123.bam", "wes_bam", "/wes/r1_L.fastq.gz"
     )
     cytof_file = make_file(
         trial_id_2, "cytof/.../analysis.zip", "cytof", "/cytof_analysis/analysis.zip"
@@ -280,7 +280,7 @@ def test_get_filelist(cidc_api, clean_db, monkeypatch):
     assert "text/tsv" in res.headers["Content-Type"]
     assert "filename=filelist.tsv" in res.headers["Content-Disposition"]
     assert res.data.decode("utf-8") == (
-        f"gs://{GOOGLE_ACL_DATA_BUCKET}/{trial_id_1}/wes/.../reads_123.bam\t{trial_id_1}_wes_..._reads_123.bam\n"
+        f'"gs://{GOOGLE_ACL_DATA_BUCKET}/{trial_id_1}/wes/.../reads 123.bam"\t{trial_id_1}_wes_..._reads_123.bam\n'
     )
 
     # Give the user a cross-assay permission
@@ -299,7 +299,7 @@ def test_get_filelist(cidc_api, clean_db, monkeypatch):
     assert "text/tsv" in res.headers["Content-Type"]
     assert "filename=filelist.tsv" in res.headers["Content-Disposition"]
     assert res.data.decode("utf-8") == (
-        f"gs://{GOOGLE_ACL_DATA_BUCKET}/{trial_id_1}/wes/.../reads_123.bam\t{trial_id_1}_wes_..._reads_123.bam\n"
+        f'"gs://{GOOGLE_ACL_DATA_BUCKET}/{trial_id_1}/wes/.../reads 123.bam"\t{trial_id_1}_wes_..._reads_123.bam\n'
     )
 
     # Admins don't need permissions to get files
@@ -309,9 +309,9 @@ def test_get_filelist(cidc_api, clean_db, monkeypatch):
 
     assert sorted(res.data.decode("utf-8").strip().split("\n")) == sorted(
         [
-            f"gs://{GOOGLE_ACL_DATA_BUCKET}/{trial_id_1}/wes/.../reads_123.bam\t{trial_id_1}_wes_..._reads_123.bam",
-            f"gs://{GOOGLE_ACL_DATA_BUCKET}/{trial_id_2}/cytof/.../analysis.zip\t{trial_id_2}_cytof_..._analysis.zip",
-            f"gs://{GOOGLE_ACL_DATA_BUCKET}/{trial_id_1}/clinical/.../file.csv\t{trial_id_1}_clinical_..._file.csv",
+            f'"gs://{GOOGLE_ACL_DATA_BUCKET}/{trial_id_1}/wes/.../reads 123.bam"\t{trial_id_1}_wes_..._reads_123.bam',
+            f'"gs://{GOOGLE_ACL_DATA_BUCKET}/{trial_id_2}/cytof/.../analysis.zip"\t{trial_id_2}_cytof_..._analysis.zip',
+            f'"gs://{GOOGLE_ACL_DATA_BUCKET}/{trial_id_1}/clinical/.../file.csv"\t{trial_id_1}_clinical_..._file.csv',
         ]
     )
 


### PR DESCRIPTION
## What

space handling to downloadable filelist.tsv url and destination

## Why

old version not compatible with cli 

## How

put quotes around gs url and replace spaces in destination file name

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
