### PR TITLE
CIDC-1573 remove stale relational tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 07 Dec 2022
+
+- `added` removal of assay_uploads and manifest_uploads along with rest of relational db in migration
+
 ## Version `0.27.26` - 02 Dec 2022
 
 - `changed` schemas bump for updated ASSAY_TO_FILEPATH constant

--- a/migrations/versions/4aaabde150d3_remove_relational_tables.py
+++ b/migrations/versions/4aaabde150d3_remove_relational_tables.py
@@ -32,10 +32,21 @@ def upgrade():
     op.drop_table('shipments')
     op.drop_table('participants')
     op.drop_table('cohorts')
+    op.drop_table('manifest_uploads')
     op.drop_table('clinical_trials')
+    op.drop_table('assay_uploads')
 
 
 def downgrade():    
+    op.create_table(
+        "assay_uploads",
+        sa.Column("_created", sa.DateTime(), nullable=True),
+        sa.Column("_updated", sa.DateTime(), nullable=True),
+        sa.Column("_etag", sa.String(length=40), nullable=True),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("status", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
     op.create_table('clinical_trials',
     sa.Column('protocol_identifier', sa.VARCHAR(), autoincrement=False, nullable=False),
     sa.Column('nct_id', sa.VARCHAR(), autoincrement=False, nullable=True),
@@ -54,6 +65,14 @@ def downgrade():
     sa.Column('data_sharing_plan', sa.VARCHAR(), autoincrement=False, nullable=True),
     sa.PrimaryKeyConstraint('protocol_identifier', name='clinical_trials_pkey'),
     postgresql_ignore_search_path=False
+    )
+    op.create_table(
+        "manifest_uploads",
+        sa.Column("_created", sa.DateTime(), nullable=True),
+        sa.Column("_updated", sa.DateTime(), nullable=True),
+        sa.Column("_etag", sa.String(length=40), nullable=True),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.PrimaryKeyConstraint("id"),
     )
     op.create_table('cohorts',
     sa.Column('trial_id', sa.VARCHAR(), autoincrement=False, nullable=False),


### PR DESCRIPTION
## What

Add dropping of `assay_uploads` and `manifest_uploads` tables along with rest of relational db in migration

## Why

Discovered by Essex while exploring staging database

## Remarks

- no bump needed

## How

- Update existing db migration
- Manually removed tables from staging, should also on prod when deployed

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
- [ ] Package version - Manually bumped the API package version in [__init__.py](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/master/cidc_api/__init__.py#L1)
